### PR TITLE
[PWPA-2500] Update plugin generated alfacase

### DIFF
--- a/src/alfasim_score/common.py
+++ b/src/alfasim_score/common.py
@@ -86,6 +86,18 @@ class AnnulusLabel(str, Enum):
 
 
 @dataclass
+class PluginReferences:
+    id_values: List[int]
+
+    def to_dict(self) -> Dict[str, Union[str, Scalar]]:
+        """Convert data to dict in order to write data to the alfacase."""
+        return {
+            "plugin_item_ids": self.id_values,
+            "container_key": "FluidContainer",
+        }
+
+
+@dataclass
 class FluidModelPvt:
     name: str
 
@@ -111,17 +123,16 @@ class SolidMechanicalProperties:
 
 @dataclass
 class AnnulusDepthTable:
-    fluid_names: List[str] = field(default_factory=lambda: [])
-    fluid_ids: List[float] = field(default_factory=lambda: [])
     initial_depths: Array = field(default_factory=lambda: Array([], LENGTH_UNIT))
     final_depths: Array = field(default_factory=lambda: Array([], LENGTH_UNIT))
+    fluid_references: PluginReferences = field(default_factory=lambda: PluginReferences([]))
 
     def to_dict(self, annulus_label: AnnulusLabel) -> Dict[str, Any]:
         """Convert data to dict in order to write data to the alfacase."""
         columns = {
-            f"fluid_id_{annulus_label.value}": self.fluid_ids,
             f"fluid_initial_measured_depth_{annulus_label.value}": self.initial_depths,
             f"fluid_final_measured_depth_{annulus_label.value}": self.final_depths,
+            f"fluid_name_{annulus_label.value}": self.fluid_references.to_dict(),
         }
         return {"columns": columns}
 

--- a/src/alfasim_score/common.py
+++ b/src/alfasim_score/common.py
@@ -1,15 +1,11 @@
 from typing import Any
 from typing import Dict
 from typing import List
-from typing import Union
 
 import numpy as np
 from barril.curve.curve import Curve
 from barril.units import Array
 from barril.units import Scalar
-from dataclasses import asdict
-from dataclasses import dataclass
-from dataclasses import field
 from enum import Enum
 
 from alfasim_score.constants import AIR_DENSITY_STANDARD
@@ -83,140 +79,6 @@ class AnnulusLabel(str, Enum):
     C = "c"
     D = "d"
     E = "e"
-
-
-class ThermalPropertyUpdateMode(str, Enum):
-    DISABLED = "Disabled"
-    FIRST_TIME_STEP = "First time step"
-    ALL_TIME_STEP = "All time steps"
-
-
-@dataclass
-class PluginReferences:
-    id_values: List[int]
-
-    def to_dict(self) -> Dict[str, Union[str, Scalar]]:
-        """Convert data to dict in order to write data to the alfacase."""
-        return {
-            "plugin_item_ids": self.id_values,
-            "container_key": "FluidContainer",
-        }
-
-
-@dataclass
-class FluidModelPvt:
-    name: str
-
-    def to_dict(self) -> Dict[str, Union[str, Scalar]]:
-        """Convert data to dict in order to write data to the alfacase."""
-        return {
-            "name": self.name,
-            "fluid_type": FluidModelType.PVT.value,
-        }
-
-
-@dataclass
-class SolidMechanicalProperties:
-    name: str
-    young_modulus: Scalar
-    poisson_ratio: Scalar
-    thermal_expansion_coefficient: Scalar
-
-    def to_dict(self) -> Dict[str, Any]:
-        """Convert data to dict in order to write data to the alfacase."""
-        return asdict(self)
-
-
-@dataclass
-class AnnulusDepthTable:
-    initial_depths: Array = field(default_factory=lambda: Array([], LENGTH_UNIT))
-    final_depths: Array = field(default_factory=lambda: Array([], LENGTH_UNIT))
-    fluid_references: PluginReferences = field(default_factory=lambda: PluginReferences([]))
-
-    def to_dict(self, annulus_label: AnnulusLabel) -> Dict[str, Any]:
-        """Convert data to dict in order to write data to the alfacase."""
-        columns = {
-            f"fluid_initial_measured_depth_{annulus_label.value}": self.initial_depths,
-            f"fluid_final_measured_depth_{annulus_label.value}": self.final_depths,
-            f"fluid_name_{annulus_label.value}": self.fluid_references.to_dict(),
-        }
-        return {"columns": columns}
-
-
-@dataclass
-class AnnulusTemperatureTable:
-    depths: Array = field(default_factory=lambda: Array([], LENGTH_UNIT))
-    temperatures: Array = field(default_factory=lambda: Array([], TEMPERATURE_UNIT))
-
-    def to_dict(self, annulus_label: AnnulusLabel) -> Dict[str, Any]:
-        """Convert data to dict in order to write data to the alfacase."""
-        columns = {
-            f"temperature_depth_{annulus_label.value}": self.depths,
-            f"temperature_{annulus_label.value}": self.temperatures,
-        }
-        return {"columns": columns}
-
-
-@dataclass
-class Annulus:
-    is_active: bool = False
-    mode_type: AnnulusModeType = AnnulusModeType.UNDISTURBED
-    initial_top_pressure: Scalar = Scalar(0.0, PRESSURE_UNIT)
-    is_open_seabed: bool = False
-    annulus_depth_table: AnnulusDepthTable = field(default_factory=lambda: AnnulusDepthTable())
-    annulus_temperature_table: AnnulusTemperatureTable = field(
-        default_factory=lambda: AnnulusTemperatureTable()
-    )
-    has_fluid_return: bool = False
-    initial_leakoff: Scalar = Scalar(0.0, VOLUME_UNIT)
-    has_pressure_relief: bool = False
-    pressure_relief: Scalar = Scalar(0.0, PRESSURE_UNIT)
-    relief_position: Scalar = Scalar(0.0, LENGTH_UNIT)
-
-    def to_dict(self, annulus_label: AnnulusLabel) -> Dict[str, Any]:
-        """Convert data to dict in order to write data to the alfacase."""
-        output = {}
-        for key, value in asdict(self).items():
-            if key == "annulus_depth_table":
-                value = self.annulus_depth_table.to_dict(annulus_label)
-            elif key == "annulus_temperature_table":
-                value = self.annulus_temperature_table.to_dict(annulus_label)
-            output[f"{key}_{annulus_label.value}"] = value
-
-        # the annular A doesn't have these parameters in plugin
-        if annulus_label == AnnulusLabel.A:
-            output.pop("pressure_relief_a")
-            output.pop("relief_position_a")
-        return output
-
-
-@dataclass
-class Annuli:
-    annulus_a: Annulus = field(default_factory=lambda: Annulus())
-    annulus_b: Annulus = field(default_factory=lambda: Annulus())
-    annulus_c: Annulus = field(default_factory=lambda: Annulus())
-    annulus_d: Annulus = field(default_factory=lambda: Annulus())
-    annulus_e: Annulus = field(default_factory=lambda: Annulus())
-
-    def to_dict(self) -> Dict[str, Any]:
-        """Convert data to dict in order to write data to the alfacase."""
-        data = {}
-        for annulus_label in AnnulusLabel:
-            data.update(getattr(self, f"annulus_{annulus_label.value}").to_dict(annulus_label))
-        return data
-
-
-@dataclass
-class Options:
-    thermal_property_update_mode: ThermalPropertyUpdateMode
-    is_gas_lift_on: bool
-
-    def to_dict(self) -> Dict[str, Any]:
-        """Convert data to dict in order to write data to the alfacase."""
-        return {
-            "thermal_property_update_mode": self.thermal_property_update_mode,
-            "is_gas_lift_on": self.is_gas_lift_on,
-        }
 
 
 def prepare_for_regression(values: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/alfasim_score/common.py
+++ b/src/alfasim_score/common.py
@@ -85,6 +85,12 @@ class AnnulusLabel(str, Enum):
     E = "e"
 
 
+class ThermalPropertyUpdateMode(str, Enum):
+    DISABLED = "Disabled"
+    FIRST_TIME_STEP = "First time step"
+    ALL_TIME_STEP = "All time steps"
+
+
 @dataclass
 class PluginReferences:
     id_values: List[int]
@@ -198,6 +204,19 @@ class Annuli:
         for annulus_label in AnnulusLabel:
             data.update(getattr(self, f"annulus_{annulus_label.value}").to_dict(annulus_label))
         return data
+
+
+@dataclass
+class Options:
+    thermal_property_update_mode: ThermalPropertyUpdateMode
+    is_gas_lift_on: bool
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert data to dict in order to write data to the alfacase."""
+        return {
+            "thermal_property_update_mode": self.thermal_property_update_mode,
+            "is_gas_lift_on": self.is_gas_lift_on,
+        }
 
 
 def prepare_for_regression(values: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/alfasim_score/conftest.py
+++ b/src/alfasim_score/conftest.py
@@ -5,6 +5,7 @@ from alfasim_score.converter.alfacase.base_operation import BaseOperationBuilder
 from alfasim_score.converter.alfacase.convert_alfacase import ScoreAlfacaseConverter
 from alfasim_score.converter.alfacase.injection_operation import InjectionOperationBuilder
 from alfasim_score.converter.alfacase.production_operation import ProductionOperationBuilder
+from alfasim_score.converter.alfacase.score_input_data import ScoreInputData
 from alfasim_score.converter.alfacase.score_input_reader import ScoreInputReader
 
 SCORE_GAS_LIFT_EXAMPLE_FILENAME = "score_input_gas_lift.json"
@@ -18,29 +19,34 @@ def score_input_gas_lift(shared_datadir: Path) -> ScoreInputReader:
 
 
 @pytest.fixture
-def alfacase_gas_lift(score_input_gas_lift: ScoreInputReader) -> ScoreAlfacaseConverter:
-    return ScoreAlfacaseConverter(score_input_gas_lift)
+def score_data_gas_lift(score_input_gas_lift: ScoreInputReader) -> ScoreInputData:
+    return ScoreInputData(score_input_gas_lift)
 
 
 @pytest.fixture
-def base_operation_gas_lift(score_input_gas_lift: ScoreInputReader) -> BaseOperationBuilder:
-    return BaseOperationBuilder(score_input_gas_lift)
+def alfacase_gas_lift(score_data_gas_lift: ScoreInputData) -> ScoreAlfacaseConverter:
+    return ScoreAlfacaseConverter(score_data_gas_lift)
+
+
+@pytest.fixture
+def base_operation_gas_lift(score_data_gas_lift: ScoreInputData) -> BaseOperationBuilder:
+    return BaseOperationBuilder(score_data_gas_lift)
 
 
 @pytest.fixture
 def production_operation_gas_lift(
-    score_input_gas_lift: ScoreInputReader,
+    score_data_gas_lift: ScoreInputData,
 ) -> ProductionOperationBuilder:
-    return ProductionOperationBuilder(score_input_gas_lift)
+    return ProductionOperationBuilder(score_data_gas_lift)
 
 
 @pytest.fixture
 def production_operation_natural_flow(shared_datadir: Path) -> ProductionOperationBuilder:
     score_input_reader = ScoreInputReader(shared_datadir / SCORE_NATURAL_FLOW_EXAMPLE_FILENAME)
-    return ProductionOperationBuilder(score_input_reader)
+    return ProductionOperationBuilder(ScoreInputData(score_input_reader))
 
 
 @pytest.fixture
 def injection_operation(shared_datadir: Path) -> InjectionOperationBuilder:
     score_input_reader = ScoreInputReader(shared_datadir / SCORE_INJECTION_EXAMPLE_FILENAME)
-    return InjectionOperationBuilder(score_input_reader)
+    return InjectionOperationBuilder(ScoreInputData(score_input_reader))

--- a/src/alfasim_score/converter/alfacase/_tests/test_build_injection_alfacase/test_create_alfacase_injection.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_build_injection_alfacase/test_create_alfacase_injection.alfacase
@@ -1937,4 +1937,73 @@ materials:
   viscosity:
     value: 0.0
     unit: cP
+- name: Brine_860
+  material_type: fluid
+  density:
+    value: 1000.0
+    unit: kg/m3
+  thermal_conductivity:
+    value: 0.6
+    unit: W/m.K
+  heat_capacity:
+    value: 4181.0
+    unit: J/kg.K
+  inner_emissivity:
+    value: 0.0
+    unit: '-'
+  outer_emissivity:
+    value: 0.0
+    unit: '-'
+  expansion:
+    value: 0.0004
+    unit: 1/K
+  viscosity:
+    value: 0.0
+    unit: cP
+- name: DFLT_FCBA_9.80
+  material_type: fluid
+  density:
+    value: 1000.0
+    unit: kg/m3
+  thermal_conductivity:
+    value: 0.6
+    unit: W/m.K
+  heat_capacity:
+    value: 4181.0
+    unit: J/kg.K
+  inner_emissivity:
+    value: 0.0
+    unit: '-'
+  outer_emissivity:
+    value: 0.0
+    unit: '-'
+  expansion:
+    value: 0.0004
+    unit: 1/K
+  viscosity:
+    value: 0.0
+    unit: cP
+- name: DFLT_FPBA_BARITE_11.50_311300
+  material_type: fluid
+  density:
+    value: 1000.0
+    unit: kg/m3
+  thermal_conductivity:
+    value: 0.6
+    unit: W/m.K
+  heat_capacity:
+    value: 4181.0
+    unit: J/kg.K
+  inner_emissivity:
+    value: 0.0
+    unit: '-'
+  outer_emissivity:
+    value: 0.0
+    unit: '-'
+  expansion:
+    value: 0.0004
+    unit: 1/K
+  viscosity:
+    value: 0.0
+    unit: cP
 walls: []

--- a/src/alfasim_score/converter/alfacase/_tests/test_build_injection_alfacase/test_create_alfacase_injection.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_build_injection_alfacase/test_create_alfacase_injection.alfacase
@@ -116,8 +116,10 @@ plugins:
             - 2975.0
             unit: m
           temperature_a:
-          - 4.0
-          - 68.69767441860465
+            values:
+            - 4.0
+            - 68.69767441860465
+            unit: degC
       has_fluid_return_a: True
       initial_leakoff_a:
         value: 0.0
@@ -151,8 +153,10 @@ plugins:
             - 2975.0
             unit: m
           temperature_b:
-          - 4.0
-          - 68.69767441860465
+            values:
+            - 4.0
+            - 68.69767441860465
+            unit: degC
       has_fluid_return_b: True
       initial_leakoff_b:
         value: 0.0
@@ -277,10 +281,13 @@ plugins:
       _children_list:
       - name: Brine_860
         fluid_type: PVT
+        pvt_table_content: Brine_860.tab
       - name: DFLT_FCBA_9.80
         fluid_type: PVT
+        pvt_table_content: DFLT_FCBA_9.80.tab
       - name: DFLT_FPBA_BARITE_11.50_311300
         fluid_type: PVT
+        pvt_table_content: DFLT_FPBA_BARITE_11.50_311300.tab
     MechanicalContainer:
       name: Mechanical Properties
       _children_list:
@@ -795,7 +802,7 @@ wells:
       top_of_filler:
         value: 0.0
         unit: m
-      filler_material: cement
+      filler_material: CM_cement
       material_above_filler: Brine_860
     - name: CONDUCTOR_JETTING_2
       hanger_depth:
@@ -820,7 +827,7 @@ wells:
       top_of_filler:
         value: 22.0
         unit: m
-      filler_material: cement
+      filler_material: CM_cement
       material_above_filler: Brine_860
     - name: SURFACE_CASING_1
       hanger_depth:
@@ -845,7 +852,7 @@ wells:
       top_of_filler:
         value: 0.0
         unit: m
-      filler_material: cement
+      filler_material: CM_cement
       material_above_filler: Brine_860
     - name: PRODUCTION_CASING_1
       hanger_depth:
@@ -870,7 +877,7 @@ wells:
       top_of_filler:
         value: 1700.0
         unit: m
-      filler_material: cement
+      filler_material: CM_cement
       material_above_filler: DFLT_FPBA_BARITE_11.50_311300
     - name: PRODUCTION_CASING_2
       hanger_depth:
@@ -895,7 +902,7 @@ wells:
       top_of_filler:
         value: 2270.0
         unit: m
-      filler_material: cement
+      filler_material: CM_cement
       material_above_filler: DFLT_FPBA_BARITE_11.50_311300
     - name: PRODUCTION_CASING_3
       hanger_depth:
@@ -920,7 +927,7 @@ wells:
       top_of_filler:
         value: 2655.0
         unit: m
-      filler_material: cement
+      filler_material: CM_cement
       material_above_filler: DFLT_FPBA_BARITE_11.50_311300
     tubings:
     - name: TUBING_1
@@ -1312,42 +1319,42 @@ wells:
       start:
         value: 2325.0
         unit: m
-      material: Folhelho
+      material: FC_Folhelho
     - name: formation_2
       start:
         value: 2744.67
         unit: m
-      material: Arenito
+      material: FC_Arenito
     - name: formation_3
       start:
         value: 2836.64
         unit: m
-      material: Folhelho
+      material: FC_Folhelho
     - name: formation_4
       start:
         value: 3001.42
         unit: m
-      material: Arenito
+      material: FC_Arenito
     - name: formation_5
       start:
         value: 3024.41
         unit: m
-      material: Folhelho
+      material: FC_Folhelho
     - name: formation_6
       start:
         value: 3535.0
         unit: m
-      material: Halita
+      material: FC_Halita
     - name: formation_7
       start:
         value: 5145.0
         unit: m
-      material: Calcario
+      material: FC_Calcario
     - name: formation_8
       start:
         value: 5515.0
         unit: m
-      material: Coquina
+      material: FC_Coquina
   top_node: WELLBORE_TOP_NODE
   bottom_node: WELLBORE_BOTTOM_NODE
   environment:

--- a/src/alfasim_score/converter/alfacase/_tests/test_build_injection_alfacase/test_create_alfacase_injection.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_build_injection_alfacase/test_create_alfacase_injection.alfacase
@@ -131,6 +131,9 @@ plugins:
       relief_position_a:
         value: 0.0
         unit: m
+      water_depth_pressure_a:
+        value: 0.0
+        unit: psi
       is_active_b: True
       mode_type_b: Undisturbed
       initial_top_pressure_b:
@@ -174,6 +177,9 @@ plugins:
       relief_position_b:
         value: 6370.377952755905
         unit: m
+      water_depth_pressure_b:
+        value: 0.0
+        unit: psi
       is_active_c: False
       mode_type_c: Undisturbed
       initial_top_pressure_c:
@@ -210,6 +216,9 @@ plugins:
       relief_position_c:
         value: 0.0
         unit: m
+      water_depth_pressure_c:
+        value: 0.0
+        unit: psi
       is_active_d: False
       mode_type_d: Undisturbed
       initial_top_pressure_d:
@@ -246,6 +255,9 @@ plugins:
       relief_position_d:
         value: 0.0
         unit: m
+      water_depth_pressure_d:
+        value: 0.0
+        unit: psi
       is_active_e: False
       mode_type_e: Undisturbed
       initial_top_pressure_e:
@@ -282,6 +294,9 @@ plugins:
       relief_position_e:
         value: 0.0
         unit: m
+      water_depth_pressure_e:
+        value: 0.0
+        unit: psi
     FluidContainer:
       name: Annulus Fluids Container
       _children_list:

--- a/src/alfasim_score/converter/alfacase/_tests/test_build_injection_alfacase/test_create_alfacase_injection.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_build_injection_alfacase/test_create_alfacase_injection.alfacase
@@ -424,6 +424,10 @@ plugins:
         thermal_expansion_coefficient:
           value: 0.0
           unit: 1/K
+    Options:
+      name: Options
+      thermal_property_update_mode: First time step
+      is_gas_lift_on: False
   is_enabled: True
 pvt_models:
   default_model: base

--- a/src/alfasim_score/converter/alfacase/_tests/test_build_injection_alfacase/test_create_alfacase_injection.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_build_injection_alfacase/test_create_alfacase_injection.alfacase
@@ -440,9 +440,6 @@ pvt_models:
   default_model: base
   tables:
     base: Water.tab
-    Brine_860: Brine_860.tab
-    DFLT_FCBA_9.80: DFLT_FCBA_9.80.tab
-    DFLT_FPBA_BARITE_11.50_311300: DFLT_FPBA_BARITE_11.50_311300.tab
 outputs:
   automatic_trend_frequency: True
   trends:

--- a/src/alfasim_score/converter/alfacase/_tests/test_build_injection_alfacase/test_create_alfacase_injection.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_build_injection_alfacase/test_create_alfacase_injection.alfacase
@@ -96,8 +96,6 @@ plugins:
       is_open_seabed_a: False
       annulus_depth_table_a:
         columns:
-          fluid_id_a:
-          - 1.0
           fluid_initial_measured_depth_a:
             values:
             - 0.0
@@ -106,6 +104,10 @@ plugins:
             values:
             - 2675.0
             unit: m
+          fluid_name_a:
+            plugin_item_ids:
+            - 1
+            container_key: FluidContainer
       annulus_temperature_table_a:
         columns:
           temperature_depth_a:
@@ -129,8 +131,6 @@ plugins:
       is_open_seabed_b: False
       annulus_depth_table_b:
         columns:
-          fluid_id_b:
-          - 2.0
           fluid_initial_measured_depth_b:
             values:
             - 0.0
@@ -139,6 +139,10 @@ plugins:
             values:
             - 2270.0
             unit: m
+          fluid_name_b:
+            plugin_item_ids:
+            - 2
+            container_key: FluidContainer
       annulus_temperature_table_b:
         columns:
           temperature_depth_b:
@@ -168,13 +172,15 @@ plugins:
       is_open_seabed_c: False
       annulus_depth_table_c:
         columns:
-          fluid_id_c: []
           fluid_initial_measured_depth_c:
             values: []
             unit: m
           fluid_final_measured_depth_c:
             values: []
             unit: m
+          fluid_name_c:
+            plugin_item_ids: []
+            container_key: FluidContainer
       annulus_temperature_table_c:
         columns:
           temperature_depth_c:
@@ -202,13 +208,15 @@ plugins:
       is_open_seabed_d: False
       annulus_depth_table_d:
         columns:
-          fluid_id_d: []
           fluid_initial_measured_depth_d:
             values: []
             unit: m
           fluid_final_measured_depth_d:
             values: []
             unit: m
+          fluid_name_d:
+            plugin_item_ids: []
+            container_key: FluidContainer
       annulus_temperature_table_d:
         columns:
           temperature_depth_d:
@@ -236,13 +244,15 @@ plugins:
       is_open_seabed_e: False
       annulus_depth_table_e:
         columns:
-          fluid_id_e: []
           fluid_initial_measured_depth_e:
             values: []
             unit: m
           fluid_final_measured_depth_e:
             values: []
             unit: m
+          fluid_name_e:
+            plugin_item_ids: []
+            container_key: FluidContainer
       annulus_temperature_table_e:
         columns:
           temperature_depth_e:

--- a/src/alfasim_score/converter/alfacase/_tests/test_build_injection_alfacase/test_create_alfacase_injection.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_build_injection_alfacase/test_create_alfacase_injection.alfacase
@@ -125,6 +125,12 @@ plugins:
         value: 0.0
         unit: m3
       has_pressure_relief_a: False
+      glv_delta_pressure_a:
+        value: 0.0
+        unit: psi
+      relief_position_a:
+        value: 0.0
+        unit: m
       is_active_b: True
       mode_type_b: Undisturbed
       initial_top_pressure_b:

--- a/src/alfasim_score/converter/alfacase/_tests/test_build_production_alfacase/test_create_alfacase_gas_lift_production.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_build_production_alfacase/test_create_alfacase_gas_lift_production.alfacase
@@ -1753,4 +1753,73 @@ materials:
   viscosity:
     value: 0.0
     unit: cP
+- name: Brine_860
+  material_type: fluid
+  density:
+    value: 1000.0
+    unit: kg/m3
+  thermal_conductivity:
+    value: 0.6
+    unit: W/m.K
+  heat_capacity:
+    value: 4181.0
+    unit: J/kg.K
+  inner_emissivity:
+    value: 0.0
+    unit: '-'
+  outer_emissivity:
+    value: 0.0
+    unit: '-'
+  expansion:
+    value: 0.0004
+    unit: 1/K
+  viscosity:
+    value: 0.0
+    unit: cP
+- name: DFLT_FCBA_9.00
+  material_type: fluid
+  density:
+    value: 1000.0
+    unit: kg/m3
+  thermal_conductivity:
+    value: 0.6
+    unit: W/m.K
+  heat_capacity:
+    value: 4181.0
+    unit: J/kg.K
+  inner_emissivity:
+    value: 0.0
+    unit: '-'
+  outer_emissivity:
+    value: 0.0
+    unit: '-'
+  expansion:
+    value: 0.0004
+    unit: 1/K
+  viscosity:
+    value: 0.0
+    unit: cP
+- name: DFLT_FPBA_BARITE_8.60_35000
+  material_type: fluid
+  density:
+    value: 1000.0
+    unit: kg/m3
+  thermal_conductivity:
+    value: 0.6
+    unit: W/m.K
+  heat_capacity:
+    value: 4181.0
+    unit: J/kg.K
+  inner_emissivity:
+    value: 0.0
+    unit: '-'
+  outer_emissivity:
+    value: 0.0
+    unit: '-'
+  expansion:
+    value: 0.0004
+    unit: 1/K
+  viscosity:
+    value: 0.0
+    unit: cP
 walls: []

--- a/src/alfasim_score/converter/alfacase/_tests/test_build_production_alfacase/test_create_alfacase_gas_lift_production.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_build_production_alfacase/test_create_alfacase_gas_lift_production.alfacase
@@ -96,8 +96,6 @@ plugins:
       is_open_seabed_a: False
       annulus_depth_table_a:
         columns:
-          fluid_id_a:
-          - 1.0
           fluid_initial_measured_depth_a:
             values:
             - 0.0
@@ -106,6 +104,10 @@ plugins:
             values:
             - 3493.1800000000003
             unit: m
+          fluid_name_a:
+            plugin_item_ids:
+            - 1
+            container_key: FluidContainer
       annulus_temperature_table_a:
         columns:
           temperature_depth_a:
@@ -159,8 +161,6 @@ plugins:
       is_open_seabed_b: False
       annulus_depth_table_b:
         columns:
-          fluid_id_b:
-          - 2.0
           fluid_initial_measured_depth_b:
             values:
             - 0.0
@@ -169,6 +169,10 @@ plugins:
             values:
             - 2833.0
             unit: m
+          fluid_name_b:
+            plugin_item_ids:
+            - 2
+            container_key: FluidContainer
       annulus_temperature_table_b:
         columns:
           temperature_depth_b:
@@ -228,13 +232,15 @@ plugins:
       is_open_seabed_c: False
       annulus_depth_table_c:
         columns:
-          fluid_id_c: []
           fluid_initial_measured_depth_c:
             values: []
             unit: m
           fluid_final_measured_depth_c:
             values: []
             unit: m
+          fluid_name_c:
+            plugin_item_ids: []
+            container_key: FluidContainer
       annulus_temperature_table_c:
         columns:
           temperature_depth_c:
@@ -262,13 +268,15 @@ plugins:
       is_open_seabed_d: False
       annulus_depth_table_d:
         columns:
-          fluid_id_d: []
           fluid_initial_measured_depth_d:
             values: []
             unit: m
           fluid_final_measured_depth_d:
             values: []
             unit: m
+          fluid_name_d:
+            plugin_item_ids: []
+            container_key: FluidContainer
       annulus_temperature_table_d:
         columns:
           temperature_depth_d:
@@ -296,13 +304,15 @@ plugins:
       is_open_seabed_e: False
       annulus_depth_table_e:
         columns:
-          fluid_id_e: []
           fluid_initial_measured_depth_e:
             values: []
             unit: m
           fluid_final_measured_depth_e:
             values: []
             unit: m
+          fluid_name_e:
+            plugin_item_ids: []
+            container_key: FluidContainer
       annulus_temperature_table_e:
         columns:
           temperature_depth_e:

--- a/src/alfasim_score/converter/alfacase/_tests/test_build_production_alfacase/test_create_alfacase_gas_lift_production.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_build_production_alfacase/test_create_alfacase_gas_lift_production.alfacase
@@ -414,6 +414,10 @@ plugins:
         thermal_expansion_coefficient:
           value: 0.0
           unit: 1/K
+    Options:
+      name: Options
+      thermal_property_update_mode: First time step
+      is_gas_lift_on: True
   is_enabled: True
 pvt_models:
   default_model: base

--- a/src/alfasim_score/converter/alfacase/_tests/test_build_production_alfacase/test_create_alfacase_gas_lift_production.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_build_production_alfacase/test_create_alfacase_gas_lift_production.alfacase
@@ -131,23 +131,25 @@ plugins:
             - 3906.79
             unit: m
           temperature_a:
-          - 4.44
-          - 5.216276362194144
-          - 45.102570507084444
-          - 45.933404962426266
-          - 46.763092625000326
-          - 47.59008242813707
-          - 48.41336681214941
-          - 49.23194273183265
-          - 50.04481287852061
-          - 50.8509868951526
-          - 51.649482582870945
-          - 52.439327097679005
-          - 53.219558135701675
-          - 53.98922510560453
-          - 54.74739028674283
-          - 55.47930539330239
-          - 105.99050193584353
+            values:
+            - 4.44
+            - 5.216276362194144
+            - 45.102570507084444
+            - 45.933404962426266
+            - 46.763092625000326
+            - 47.59008242813707
+            - 48.41336681214941
+            - 49.23194273183265
+            - 50.04481287852061
+            - 50.8509868951526
+            - 51.649482582870945
+            - 52.439327097679005
+            - 53.219558135701675
+            - 53.98922510560453
+            - 54.74739028674283
+            - 55.47930539330239
+            - 105.99050193584353
+            unit: degC
       has_fluid_return_a: True
       initial_leakoff_a:
         value: 0.0
@@ -196,23 +198,25 @@ plugins:
             - 3906.79
             unit: m
           temperature_b:
-          - 4.44
-          - 5.216276362194144
-          - 45.102570507084444
-          - 45.933404962426266
-          - 46.763092625000326
-          - 47.59008242813707
-          - 48.41336681214941
-          - 49.23194273183265
-          - 50.04481287852061
-          - 50.8509868951526
-          - 51.649482582870945
-          - 52.439327097679005
-          - 53.219558135701675
-          - 53.98922510560453
-          - 54.74739028674283
-          - 55.47930539330239
-          - 105.99050193584353
+            values:
+            - 4.44
+            - 5.216276362194144
+            - 45.102570507084444
+            - 45.933404962426266
+            - 46.763092625000326
+            - 47.59008242813707
+            - 48.41336681214941
+            - 49.23194273183265
+            - 50.04481287852061
+            - 50.8509868951526
+            - 51.649482582870945
+            - 52.439327097679005
+            - 53.219558135701675
+            - 53.98922510560453
+            - 54.74739028674283
+            - 55.47930539330239
+            - 105.99050193584353
+            unit: degC
       has_fluid_return_b: True
       initial_leakoff_b:
         value: 0.0
@@ -337,10 +341,13 @@ plugins:
       _children_list:
       - name: Brine_860
         fluid_type: PVT
+        pvt_table_content: Brine_860.tab
       - name: DFLT_FCBA_9.00
         fluid_type: PVT
+        pvt_table_content: DFLT_FCBA_9.00.tab
       - name: DFLT_FPBA_BARITE_8.60_35000
         fluid_type: PVT
+        pvt_table_content: DFLT_FPBA_BARITE_8.60_35000.tab
     MechanicalContainer:
       name: Mechanical Properties
       _children_list:
@@ -826,7 +833,7 @@ wells:
       top_of_filler:
         value: 0.0
         unit: m
-      filler_material: cement
+      filler_material: CM_cement
       material_above_filler: Brine_860
     - name: SURFACE_CASING_1
       hanger_depth:
@@ -851,7 +858,7 @@ wells:
       top_of_filler:
         value: 0.0
         unit: m
-      filler_material: cement
+      filler_material: CM_cement
       material_above_filler: Brine_860
     - name: PRODUCTION_CASING_1
       hanger_depth:
@@ -876,7 +883,7 @@ wells:
       top_of_filler:
         value: 1000.0
         unit: m
-      filler_material: cement
+      filler_material: CM_cement
       material_above_filler: DFLT_FPBA_BARITE_8.60_35000
     - name: PRODUCTION_CASING_2
       hanger_depth:
@@ -901,7 +908,7 @@ wells:
       top_of_filler:
         value: 2833.0
         unit: m
-      filler_material: cement
+      filler_material: CM_cement
       material_above_filler: DFLT_FPBA_BARITE_8.60_35000
     - name: PRODUCTION_CASING_3
       hanger_depth:
@@ -926,7 +933,7 @@ wells:
       top_of_filler:
         value: 3369.0
         unit: m
-      filler_material: cement
+      filler_material: CM_cement
       material_above_filler: DFLT_FPBA_BARITE_8.60_35000
     tubings:
     - name: TUBING_1
@@ -1356,7 +1363,7 @@ wells:
       start:
         value: 2072.0
         unit: m
-      material: Folhelho
+      material: FC_Folhelho
   top_node: WELLBORE_TOP_NODE
   bottom_node: WELLBORE_BOTTOM_NODE
   environment:

--- a/src/alfasim_score/converter/alfacase/_tests/test_build_production_alfacase/test_create_alfacase_gas_lift_production.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_build_production_alfacase/test_create_alfacase_gas_lift_production.alfacase
@@ -430,9 +430,6 @@ pvt_models:
   default_model: base
   tables:
     base: DFLT_BLACK_OIL_27.40_230.00_1.17.tab
-    Brine_860: Brine_860.tab
-    DFLT_FCBA_9.00: DFLT_FCBA_9.00.tab
-    DFLT_FPBA_BARITE_8.60_35000: DFLT_FPBA_BARITE_8.60_35000.tab
   correlations:
     DFLT_BLACK_OIL_27.40_230.00_1.17:
       oil_density_std:

--- a/src/alfasim_score/converter/alfacase/_tests/test_build_production_alfacase/test_create_alfacase_gas_lift_production.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_build_production_alfacase/test_create_alfacase_gas_lift_production.alfacase
@@ -161,6 +161,9 @@ plugins:
       relief_position_a:
         value: 0.0
         unit: m
+      water_depth_pressure_a:
+        value: 0.0
+        unit: psi
       is_active_b: True
       mode_type_b: Undisturbed
       initial_top_pressure_b:
@@ -234,6 +237,9 @@ plugins:
       relief_position_b:
         value: -2072.0
         unit: m
+      water_depth_pressure_b:
+        value: 0.0
+        unit: psi
       is_active_c: False
       mode_type_c: Undisturbed
       initial_top_pressure_c:
@@ -270,6 +276,9 @@ plugins:
       relief_position_c:
         value: 0.0
         unit: m
+      water_depth_pressure_c:
+        value: 0.0
+        unit: psi
       is_active_d: False
       mode_type_d: Undisturbed
       initial_top_pressure_d:
@@ -306,6 +315,9 @@ plugins:
       relief_position_d:
         value: 0.0
         unit: m
+      water_depth_pressure_d:
+        value: 0.0
+        unit: psi
       is_active_e: False
       mode_type_e: Undisturbed
       initial_top_pressure_e:
@@ -342,6 +354,9 @@ plugins:
       relief_position_e:
         value: 0.0
         unit: m
+      water_depth_pressure_e:
+        value: 0.0
+        unit: psi
     FluidContainer:
       name: Annulus Fluids Container
       _children_list:

--- a/src/alfasim_score/converter/alfacase/_tests/test_build_production_alfacase/test_create_alfacase_gas_lift_production.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_build_production_alfacase/test_create_alfacase_gas_lift_production.alfacase
@@ -155,6 +155,12 @@ plugins:
         value: 0.0
         unit: m3
       has_pressure_relief_a: False
+      glv_delta_pressure_a:
+        value: 0.0
+        unit: psi
+      relief_position_a:
+        value: 0.0
+        unit: m
       is_active_b: True
       mode_type_b: Undisturbed
       initial_top_pressure_b:

--- a/src/alfasim_score/converter/alfacase/_tests/test_build_production_alfacase/test_create_alfacase_natural_flow_production.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_build_production_alfacase/test_create_alfacase_natural_flow_production.alfacase
@@ -1737,4 +1737,73 @@ materials:
   viscosity:
     value: 0.0
     unit: cP
+- name: Brine_860
+  material_type: fluid
+  density:
+    value: 1000.0
+    unit: kg/m3
+  thermal_conductivity:
+    value: 0.6
+    unit: W/m.K
+  heat_capacity:
+    value: 4181.0
+    unit: J/kg.K
+  inner_emissivity:
+    value: 0.0
+    unit: '-'
+  outer_emissivity:
+    value: 0.0
+    unit: '-'
+  expansion:
+    value: 0.0004
+    unit: 1/K
+  viscosity:
+    value: 0.0
+    unit: cP
+- name: DFLT_FCBA_9.03
+  material_type: fluid
+  density:
+    value: 1000.0
+    unit: kg/m3
+  thermal_conductivity:
+    value: 0.6
+    unit: W/m.K
+  heat_capacity:
+    value: 4181.0
+    unit: J/kg.K
+  inner_emissivity:
+    value: 0.0
+    unit: '-'
+  outer_emissivity:
+    value: 0.0
+    unit: '-'
+  expansion:
+    value: 0.0004
+    unit: 1/K
+  viscosity:
+    value: 0.0
+    unit: cP
+- name: DFLT_FPBA_BARITE_8.60_35000
+  material_type: fluid
+  density:
+    value: 1000.0
+    unit: kg/m3
+  thermal_conductivity:
+    value: 0.6
+    unit: W/m.K
+  heat_capacity:
+    value: 4181.0
+    unit: J/kg.K
+  inner_emissivity:
+    value: 0.0
+    unit: '-'
+  outer_emissivity:
+    value: 0.0
+    unit: '-'
+  expansion:
+    value: 0.0004
+    unit: 1/K
+  viscosity:
+    value: 0.0
+    unit: cP
 walls: []

--- a/src/alfasim_score/converter/alfacase/_tests/test_build_production_alfacase/test_create_alfacase_natural_flow_production.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_build_production_alfacase/test_create_alfacase_natural_flow_production.alfacase
@@ -414,6 +414,10 @@ plugins:
         thermal_expansion_coefficient:
           value: 0.0
           unit: 1/K
+    Options:
+      name: Options
+      thermal_property_update_mode: First time step
+      is_gas_lift_on: False
   is_enabled: True
 pvt_models:
   default_model: base

--- a/src/alfasim_score/converter/alfacase/_tests/test_build_production_alfacase/test_create_alfacase_natural_flow_production.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_build_production_alfacase/test_create_alfacase_natural_flow_production.alfacase
@@ -430,9 +430,6 @@ pvt_models:
   default_model: base
   tables:
     base: DFLT_BLACK_OIL_27.40_230.00_1.17.tab
-    Brine_860: Brine_860.tab
-    DFLT_FCBA_9.03: DFLT_FCBA_9.03.tab
-    DFLT_FPBA_BARITE_8.60_35000: DFLT_FPBA_BARITE_8.60_35000.tab
   correlations:
     DFLT_BLACK_OIL_27.40_230.00_1.17:
       oil_density_std:

--- a/src/alfasim_score/converter/alfacase/_tests/test_build_production_alfacase/test_create_alfacase_natural_flow_production.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_build_production_alfacase/test_create_alfacase_natural_flow_production.alfacase
@@ -96,8 +96,6 @@ plugins:
       is_open_seabed_a: False
       annulus_depth_table_a:
         columns:
-          fluid_id_a:
-          - 1.0
           fluid_initial_measured_depth_a:
             values:
             - 0.0
@@ -106,6 +104,10 @@ plugins:
             values:
             - 3493.1800000000003
             unit: m
+          fluid_name_a:
+            plugin_item_ids:
+            - 1
+            container_key: FluidContainer
       annulus_temperature_table_a:
         columns:
           temperature_depth_a:
@@ -159,8 +161,6 @@ plugins:
       is_open_seabed_b: False
       annulus_depth_table_b:
         columns:
-          fluid_id_b:
-          - 2.0
           fluid_initial_measured_depth_b:
             values:
             - 0.0
@@ -169,6 +169,10 @@ plugins:
             values:
             - 2833.0
             unit: m
+          fluid_name_b:
+            plugin_item_ids:
+            - 2
+            container_key: FluidContainer
       annulus_temperature_table_b:
         columns:
           temperature_depth_b:
@@ -228,13 +232,15 @@ plugins:
       is_open_seabed_c: False
       annulus_depth_table_c:
         columns:
-          fluid_id_c: []
           fluid_initial_measured_depth_c:
             values: []
             unit: m
           fluid_final_measured_depth_c:
             values: []
             unit: m
+          fluid_name_c:
+            plugin_item_ids: []
+            container_key: FluidContainer
       annulus_temperature_table_c:
         columns:
           temperature_depth_c:
@@ -262,13 +268,15 @@ plugins:
       is_open_seabed_d: False
       annulus_depth_table_d:
         columns:
-          fluid_id_d: []
           fluid_initial_measured_depth_d:
             values: []
             unit: m
           fluid_final_measured_depth_d:
             values: []
             unit: m
+          fluid_name_d:
+            plugin_item_ids: []
+            container_key: FluidContainer
       annulus_temperature_table_d:
         columns:
           temperature_depth_d:
@@ -296,13 +304,15 @@ plugins:
       is_open_seabed_e: False
       annulus_depth_table_e:
         columns:
-          fluid_id_e: []
           fluid_initial_measured_depth_e:
             values: []
             unit: m
           fluid_final_measured_depth_e:
             values: []
             unit: m
+          fluid_name_e:
+            plugin_item_ids: []
+            container_key: FluidContainer
       annulus_temperature_table_e:
         columns:
           temperature_depth_e:

--- a/src/alfasim_score/converter/alfacase/_tests/test_build_production_alfacase/test_create_alfacase_natural_flow_production.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_build_production_alfacase/test_create_alfacase_natural_flow_production.alfacase
@@ -131,23 +131,25 @@ plugins:
             - 3906.79
             unit: m
           temperature_a:
-          - 4.44
-          - 5.216276362194144
-          - 45.102570507084444
-          - 45.933404962426266
-          - 46.763092625000326
-          - 47.59008242813707
-          - 48.41336681214941
-          - 49.23194273183265
-          - 50.04481287852061
-          - 50.8509868951526
-          - 51.649482582870945
-          - 52.439327097679005
-          - 53.219558135701675
-          - 53.98922510560453
-          - 54.74739028674283
-          - 55.47930539330239
-          - 105.99050193584353
+            values:
+            - 4.44
+            - 5.216276362194144
+            - 45.102570507084444
+            - 45.933404962426266
+            - 46.763092625000326
+            - 47.59008242813707
+            - 48.41336681214941
+            - 49.23194273183265
+            - 50.04481287852061
+            - 50.8509868951526
+            - 51.649482582870945
+            - 52.439327097679005
+            - 53.219558135701675
+            - 53.98922510560453
+            - 54.74739028674283
+            - 55.47930539330239
+            - 105.99050193584353
+            unit: degC
       has_fluid_return_a: True
       initial_leakoff_a:
         value: 0.0
@@ -196,23 +198,25 @@ plugins:
             - 3906.79
             unit: m
           temperature_b:
-          - 4.44
-          - 5.216276362194144
-          - 45.102570507084444
-          - 45.933404962426266
-          - 46.763092625000326
-          - 47.59008242813707
-          - 48.41336681214941
-          - 49.23194273183265
-          - 50.04481287852061
-          - 50.8509868951526
-          - 51.649482582870945
-          - 52.439327097679005
-          - 53.219558135701675
-          - 53.98922510560453
-          - 54.74739028674283
-          - 55.47930539330239
-          - 105.99050193584353
+            values:
+            - 4.44
+            - 5.216276362194144
+            - 45.102570507084444
+            - 45.933404962426266
+            - 46.763092625000326
+            - 47.59008242813707
+            - 48.41336681214941
+            - 49.23194273183265
+            - 50.04481287852061
+            - 50.8509868951526
+            - 51.649482582870945
+            - 52.439327097679005
+            - 53.219558135701675
+            - 53.98922510560453
+            - 54.74739028674283
+            - 55.47930539330239
+            - 105.99050193584353
+            unit: degC
       has_fluid_return_b: True
       initial_leakoff_b:
         value: 0.0
@@ -337,10 +341,13 @@ plugins:
       _children_list:
       - name: Brine_860
         fluid_type: PVT
+        pvt_table_content: Brine_860.tab
       - name: DFLT_FCBA_9.03
         fluid_type: PVT
+        pvt_table_content: DFLT_FCBA_9.03.tab
       - name: DFLT_FPBA_BARITE_8.60_35000
         fluid_type: PVT
+        pvt_table_content: DFLT_FPBA_BARITE_8.60_35000.tab
     MechanicalContainer:
       name: Mechanical Properties
       _children_list:
@@ -826,7 +833,7 @@ wells:
       top_of_filler:
         value: 0.0
         unit: m
-      filler_material: cement
+      filler_material: CM_cement
       material_above_filler: Brine_860
     - name: SURFACE_CASING_1
       hanger_depth:
@@ -851,7 +858,7 @@ wells:
       top_of_filler:
         value: 0.0
         unit: m
-      filler_material: cement
+      filler_material: CM_cement
       material_above_filler: Brine_860
     - name: PRODUCTION_CASING_1
       hanger_depth:
@@ -876,7 +883,7 @@ wells:
       top_of_filler:
         value: 1000.0
         unit: m
-      filler_material: cement
+      filler_material: CM_cement
       material_above_filler: DFLT_FPBA_BARITE_8.60_35000
     - name: PRODUCTION_CASING_2
       hanger_depth:
@@ -901,7 +908,7 @@ wells:
       top_of_filler:
         value: 2833.0
         unit: m
-      filler_material: cement
+      filler_material: CM_cement
       material_above_filler: DFLT_FPBA_BARITE_8.60_35000
     - name: PRODUCTION_CASING_3
       hanger_depth:
@@ -926,7 +933,7 @@ wells:
       top_of_filler:
         value: 3369.0
         unit: m
-      filler_material: cement
+      filler_material: CM_cement
       material_above_filler: DFLT_FPBA_BARITE_8.60_35000
     tubings:
     - name: TUBING_1
@@ -1340,7 +1347,7 @@ wells:
       start:
         value: 2072.0
         unit: m
-      material: Folhelho
+      material: FC_Folhelho
   top_node: WELLBORE_TOP_NODE
   bottom_node: WELLBORE_BOTTOM_NODE
   environment:

--- a/src/alfasim_score/converter/alfacase/_tests/test_build_production_alfacase/test_create_alfacase_natural_flow_production.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_build_production_alfacase/test_create_alfacase_natural_flow_production.alfacase
@@ -161,6 +161,9 @@ plugins:
       relief_position_a:
         value: 0.0
         unit: m
+      water_depth_pressure_a:
+        value: 0.0
+        unit: psi
       is_active_b: True
       mode_type_b: Undisturbed
       initial_top_pressure_b:
@@ -234,6 +237,9 @@ plugins:
       relief_position_b:
         value: -2072.0
         unit: m
+      water_depth_pressure_b:
+        value: 0.0
+        unit: psi
       is_active_c: False
       mode_type_c: Undisturbed
       initial_top_pressure_c:
@@ -270,6 +276,9 @@ plugins:
       relief_position_c:
         value: 0.0
         unit: m
+      water_depth_pressure_c:
+        value: 0.0
+        unit: psi
       is_active_d: False
       mode_type_d: Undisturbed
       initial_top_pressure_d:
@@ -306,6 +315,9 @@ plugins:
       relief_position_d:
         value: 0.0
         unit: m
+      water_depth_pressure_d:
+        value: 0.0
+        unit: psi
       is_active_e: False
       mode_type_e: Undisturbed
       initial_top_pressure_e:
@@ -342,6 +354,9 @@ plugins:
       relief_position_e:
         value: 0.0
         unit: m
+      water_depth_pressure_e:
+        value: 0.0
+        unit: psi
     FluidContainer:
       name: Annulus Fluids Container
       _children_list:

--- a/src/alfasim_score/converter/alfacase/_tests/test_build_production_alfacase/test_create_alfacase_natural_flow_production.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_build_production_alfacase/test_create_alfacase_natural_flow_production.alfacase
@@ -155,6 +155,12 @@ plugins:
         value: 0.0
         unit: m3
       has_pressure_relief_a: False
+      glv_delta_pressure_a:
+        value: 0.0
+        unit: psi
+      relief_position_a:
+        value: 0.0
+        unit: m
       is_active_b: True
       mode_type_b: Undisturbed
       initial_top_pressure_b:

--- a/src/alfasim_score/converter/alfacase/_tests/test_convert_alfacase/test_create_alfacase_file_score_input_injection_operation_.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_convert_alfacase/test_create_alfacase_file_score_input_injection_operation_.alfacase
@@ -1937,4 +1937,73 @@ materials:
   viscosity:
     value: 0.0
     unit: cP
+- name: Brine_860
+  material_type: fluid
+  density:
+    value: 1000.0
+    unit: kg/m3
+  thermal_conductivity:
+    value: 0.6
+    unit: W/m.K
+  heat_capacity:
+    value: 4181.0
+    unit: J/kg.K
+  inner_emissivity:
+    value: 0.0
+    unit: '-'
+  outer_emissivity:
+    value: 0.0
+    unit: '-'
+  expansion:
+    value: 0.0004
+    unit: 1/K
+  viscosity:
+    value: 0.0
+    unit: cP
+- name: DFLT_FCBA_9.80
+  material_type: fluid
+  density:
+    value: 1000.0
+    unit: kg/m3
+  thermal_conductivity:
+    value: 0.6
+    unit: W/m.K
+  heat_capacity:
+    value: 4181.0
+    unit: J/kg.K
+  inner_emissivity:
+    value: 0.0
+    unit: '-'
+  outer_emissivity:
+    value: 0.0
+    unit: '-'
+  expansion:
+    value: 0.0004
+    unit: 1/K
+  viscosity:
+    value: 0.0
+    unit: cP
+- name: DFLT_FPBA_BARITE_11.50_311300
+  material_type: fluid
+  density:
+    value: 1000.0
+    unit: kg/m3
+  thermal_conductivity:
+    value: 0.6
+    unit: W/m.K
+  heat_capacity:
+    value: 4181.0
+    unit: J/kg.K
+  inner_emissivity:
+    value: 0.0
+    unit: '-'
+  outer_emissivity:
+    value: 0.0
+    unit: '-'
+  expansion:
+    value: 0.0004
+    unit: 1/K
+  viscosity:
+    value: 0.0
+    unit: cP
 walls: []

--- a/src/alfasim_score/converter/alfacase/_tests/test_convert_alfacase/test_create_alfacase_file_score_input_injection_operation_.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_convert_alfacase/test_create_alfacase_file_score_input_injection_operation_.alfacase
@@ -116,8 +116,10 @@ plugins:
             - 2975.0
             unit: m
           temperature_a:
-          - 4.0
-          - 68.69767441860465
+            values:
+            - 4.0
+            - 68.69767441860465
+            unit: degC
       has_fluid_return_a: True
       initial_leakoff_a:
         value: 0.0
@@ -151,8 +153,10 @@ plugins:
             - 2975.0
             unit: m
           temperature_b:
-          - 4.0
-          - 68.69767441860465
+            values:
+            - 4.0
+            - 68.69767441860465
+            unit: degC
       has_fluid_return_b: True
       initial_leakoff_b:
         value: 0.0
@@ -277,10 +281,13 @@ plugins:
       _children_list:
       - name: Brine_860
         fluid_type: PVT
+        pvt_table_content: Brine_860.tab
       - name: DFLT_FCBA_9.80
         fluid_type: PVT
+        pvt_table_content: DFLT_FCBA_9.80.tab
       - name: DFLT_FPBA_BARITE_11.50_311300
         fluid_type: PVT
+        pvt_table_content: DFLT_FPBA_BARITE_11.50_311300.tab
     MechanicalContainer:
       name: Mechanical Properties
       _children_list:
@@ -795,7 +802,7 @@ wells:
       top_of_filler:
         value: 0.0
         unit: m
-      filler_material: cement
+      filler_material: CM_cement
       material_above_filler: Brine_860
     - name: CONDUCTOR_JETTING_2
       hanger_depth:
@@ -820,7 +827,7 @@ wells:
       top_of_filler:
         value: 22.0
         unit: m
-      filler_material: cement
+      filler_material: CM_cement
       material_above_filler: Brine_860
     - name: SURFACE_CASING_1
       hanger_depth:
@@ -845,7 +852,7 @@ wells:
       top_of_filler:
         value: 0.0
         unit: m
-      filler_material: cement
+      filler_material: CM_cement
       material_above_filler: Brine_860
     - name: PRODUCTION_CASING_1
       hanger_depth:
@@ -870,7 +877,7 @@ wells:
       top_of_filler:
         value: 1700.0
         unit: m
-      filler_material: cement
+      filler_material: CM_cement
       material_above_filler: DFLT_FPBA_BARITE_11.50_311300
     - name: PRODUCTION_CASING_2
       hanger_depth:
@@ -895,7 +902,7 @@ wells:
       top_of_filler:
         value: 2270.0
         unit: m
-      filler_material: cement
+      filler_material: CM_cement
       material_above_filler: DFLT_FPBA_BARITE_11.50_311300
     - name: PRODUCTION_CASING_3
       hanger_depth:
@@ -920,7 +927,7 @@ wells:
       top_of_filler:
         value: 2655.0
         unit: m
-      filler_material: cement
+      filler_material: CM_cement
       material_above_filler: DFLT_FPBA_BARITE_11.50_311300
     tubings:
     - name: TUBING_1
@@ -1312,42 +1319,42 @@ wells:
       start:
         value: 2325.0
         unit: m
-      material: Folhelho
+      material: FC_Folhelho
     - name: formation_2
       start:
         value: 2744.67
         unit: m
-      material: Arenito
+      material: FC_Arenito
     - name: formation_3
       start:
         value: 2836.64
         unit: m
-      material: Folhelho
+      material: FC_Folhelho
     - name: formation_4
       start:
         value: 3001.42
         unit: m
-      material: Arenito
+      material: FC_Arenito
     - name: formation_5
       start:
         value: 3024.41
         unit: m
-      material: Folhelho
+      material: FC_Folhelho
     - name: formation_6
       start:
         value: 3535.0
         unit: m
-      material: Halita
+      material: FC_Halita
     - name: formation_7
       start:
         value: 5145.0
         unit: m
-      material: Calcario
+      material: FC_Calcario
     - name: formation_8
       start:
         value: 5515.0
         unit: m
-      material: Coquina
+      material: FC_Coquina
   top_node: WELLBORE_TOP_NODE
   bottom_node: WELLBORE_BOTTOM_NODE
   environment:

--- a/src/alfasim_score/converter/alfacase/_tests/test_convert_alfacase/test_create_alfacase_file_score_input_injection_operation_.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_convert_alfacase/test_create_alfacase_file_score_input_injection_operation_.alfacase
@@ -131,6 +131,9 @@ plugins:
       relief_position_a:
         value: 0.0
         unit: m
+      water_depth_pressure_a:
+        value: 0.0
+        unit: psi
       is_active_b: True
       mode_type_b: Undisturbed
       initial_top_pressure_b:
@@ -174,6 +177,9 @@ plugins:
       relief_position_b:
         value: 6370.377952755905
         unit: m
+      water_depth_pressure_b:
+        value: 0.0
+        unit: psi
       is_active_c: False
       mode_type_c: Undisturbed
       initial_top_pressure_c:
@@ -210,6 +216,9 @@ plugins:
       relief_position_c:
         value: 0.0
         unit: m
+      water_depth_pressure_c:
+        value: 0.0
+        unit: psi
       is_active_d: False
       mode_type_d: Undisturbed
       initial_top_pressure_d:
@@ -246,6 +255,9 @@ plugins:
       relief_position_d:
         value: 0.0
         unit: m
+      water_depth_pressure_d:
+        value: 0.0
+        unit: psi
       is_active_e: False
       mode_type_e: Undisturbed
       initial_top_pressure_e:
@@ -282,6 +294,9 @@ plugins:
       relief_position_e:
         value: 0.0
         unit: m
+      water_depth_pressure_e:
+        value: 0.0
+        unit: psi
     FluidContainer:
       name: Annulus Fluids Container
       _children_list:

--- a/src/alfasim_score/converter/alfacase/_tests/test_convert_alfacase/test_create_alfacase_file_score_input_injection_operation_.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_convert_alfacase/test_create_alfacase_file_score_input_injection_operation_.alfacase
@@ -424,6 +424,10 @@ plugins:
         thermal_expansion_coefficient:
           value: 0.0
           unit: 1/K
+    Options:
+      name: Options
+      thermal_property_update_mode: First time step
+      is_gas_lift_on: False
   is_enabled: True
 pvt_models:
   default_model: base

--- a/src/alfasim_score/converter/alfacase/_tests/test_convert_alfacase/test_create_alfacase_file_score_input_injection_operation_.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_convert_alfacase/test_create_alfacase_file_score_input_injection_operation_.alfacase
@@ -440,9 +440,6 @@ pvt_models:
   default_model: base
   tables:
     base: Water.tab
-    Brine_860: Brine_860.tab
-    DFLT_FCBA_9.80: DFLT_FCBA_9.80.tab
-    DFLT_FPBA_BARITE_11.50_311300: DFLT_FPBA_BARITE_11.50_311300.tab
 outputs:
   automatic_trend_frequency: True
   trends:

--- a/src/alfasim_score/converter/alfacase/_tests/test_convert_alfacase/test_create_alfacase_file_score_input_injection_operation_.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_convert_alfacase/test_create_alfacase_file_score_input_injection_operation_.alfacase
@@ -96,8 +96,6 @@ plugins:
       is_open_seabed_a: False
       annulus_depth_table_a:
         columns:
-          fluid_id_a:
-          - 1.0
           fluid_initial_measured_depth_a:
             values:
             - 0.0
@@ -106,6 +104,10 @@ plugins:
             values:
             - 2675.0
             unit: m
+          fluid_name_a:
+            plugin_item_ids:
+            - 1
+            container_key: FluidContainer
       annulus_temperature_table_a:
         columns:
           temperature_depth_a:
@@ -129,8 +131,6 @@ plugins:
       is_open_seabed_b: False
       annulus_depth_table_b:
         columns:
-          fluid_id_b:
-          - 2.0
           fluid_initial_measured_depth_b:
             values:
             - 0.0
@@ -139,6 +139,10 @@ plugins:
             values:
             - 2270.0
             unit: m
+          fluid_name_b:
+            plugin_item_ids:
+            - 2
+            container_key: FluidContainer
       annulus_temperature_table_b:
         columns:
           temperature_depth_b:
@@ -168,13 +172,15 @@ plugins:
       is_open_seabed_c: False
       annulus_depth_table_c:
         columns:
-          fluid_id_c: []
           fluid_initial_measured_depth_c:
             values: []
             unit: m
           fluid_final_measured_depth_c:
             values: []
             unit: m
+          fluid_name_c:
+            plugin_item_ids: []
+            container_key: FluidContainer
       annulus_temperature_table_c:
         columns:
           temperature_depth_c:
@@ -202,13 +208,15 @@ plugins:
       is_open_seabed_d: False
       annulus_depth_table_d:
         columns:
-          fluid_id_d: []
           fluid_initial_measured_depth_d:
             values: []
             unit: m
           fluid_final_measured_depth_d:
             values: []
             unit: m
+          fluid_name_d:
+            plugin_item_ids: []
+            container_key: FluidContainer
       annulus_temperature_table_d:
         columns:
           temperature_depth_d:
@@ -236,13 +244,15 @@ plugins:
       is_open_seabed_e: False
       annulus_depth_table_e:
         columns:
-          fluid_id_e: []
           fluid_initial_measured_depth_e:
             values: []
             unit: m
           fluid_final_measured_depth_e:
             values: []
             unit: m
+          fluid_name_e:
+            plugin_item_ids: []
+            container_key: FluidContainer
       annulus_temperature_table_e:
         columns:
           temperature_depth_e:

--- a/src/alfasim_score/converter/alfacase/_tests/test_convert_alfacase/test_create_alfacase_file_score_input_injection_operation_.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_convert_alfacase/test_create_alfacase_file_score_input_injection_operation_.alfacase
@@ -125,6 +125,12 @@ plugins:
         value: 0.0
         unit: m3
       has_pressure_relief_a: False
+      glv_delta_pressure_a:
+        value: 0.0
+        unit: psi
+      relief_position_a:
+        value: 0.0
+        unit: m
       is_active_b: True
       mode_type_b: Undisturbed
       initial_top_pressure_b:

--- a/src/alfasim_score/converter/alfacase/_tests/test_convert_alfacase/test_create_alfacase_file_score_input_natural_flow_.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_convert_alfacase/test_create_alfacase_file_score_input_natural_flow_.alfacase
@@ -1737,4 +1737,73 @@ materials:
   viscosity:
     value: 0.0
     unit: cP
+- name: Brine_860
+  material_type: fluid
+  density:
+    value: 1000.0
+    unit: kg/m3
+  thermal_conductivity:
+    value: 0.6
+    unit: W/m.K
+  heat_capacity:
+    value: 4181.0
+    unit: J/kg.K
+  inner_emissivity:
+    value: 0.0
+    unit: '-'
+  outer_emissivity:
+    value: 0.0
+    unit: '-'
+  expansion:
+    value: 0.0004
+    unit: 1/K
+  viscosity:
+    value: 0.0
+    unit: cP
+- name: DFLT_FCBA_9.03
+  material_type: fluid
+  density:
+    value: 1000.0
+    unit: kg/m3
+  thermal_conductivity:
+    value: 0.6
+    unit: W/m.K
+  heat_capacity:
+    value: 4181.0
+    unit: J/kg.K
+  inner_emissivity:
+    value: 0.0
+    unit: '-'
+  outer_emissivity:
+    value: 0.0
+    unit: '-'
+  expansion:
+    value: 0.0004
+    unit: 1/K
+  viscosity:
+    value: 0.0
+    unit: cP
+- name: DFLT_FPBA_BARITE_8.60_35000
+  material_type: fluid
+  density:
+    value: 1000.0
+    unit: kg/m3
+  thermal_conductivity:
+    value: 0.6
+    unit: W/m.K
+  heat_capacity:
+    value: 4181.0
+    unit: J/kg.K
+  inner_emissivity:
+    value: 0.0
+    unit: '-'
+  outer_emissivity:
+    value: 0.0
+    unit: '-'
+  expansion:
+    value: 0.0004
+    unit: 1/K
+  viscosity:
+    value: 0.0
+    unit: cP
 walls: []

--- a/src/alfasim_score/converter/alfacase/_tests/test_convert_alfacase/test_create_alfacase_file_score_input_natural_flow_.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_convert_alfacase/test_create_alfacase_file_score_input_natural_flow_.alfacase
@@ -414,6 +414,10 @@ plugins:
         thermal_expansion_coefficient:
           value: 0.0
           unit: 1/K
+    Options:
+      name: Options
+      thermal_property_update_mode: First time step
+      is_gas_lift_on: False
   is_enabled: True
 pvt_models:
   default_model: base

--- a/src/alfasim_score/converter/alfacase/_tests/test_convert_alfacase/test_create_alfacase_file_score_input_natural_flow_.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_convert_alfacase/test_create_alfacase_file_score_input_natural_flow_.alfacase
@@ -430,9 +430,6 @@ pvt_models:
   default_model: base
   tables:
     base: DFLT_BLACK_OIL_27.40_230.00_1.17.tab
-    Brine_860: Brine_860.tab
-    DFLT_FCBA_9.03: DFLT_FCBA_9.03.tab
-    DFLT_FPBA_BARITE_8.60_35000: DFLT_FPBA_BARITE_8.60_35000.tab
   correlations:
     DFLT_BLACK_OIL_27.40_230.00_1.17:
       oil_density_std:

--- a/src/alfasim_score/converter/alfacase/_tests/test_convert_alfacase/test_create_alfacase_file_score_input_natural_flow_.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_convert_alfacase/test_create_alfacase_file_score_input_natural_flow_.alfacase
@@ -96,8 +96,6 @@ plugins:
       is_open_seabed_a: False
       annulus_depth_table_a:
         columns:
-          fluid_id_a:
-          - 1.0
           fluid_initial_measured_depth_a:
             values:
             - 0.0
@@ -106,6 +104,10 @@ plugins:
             values:
             - 3493.1800000000003
             unit: m
+          fluid_name_a:
+            plugin_item_ids:
+            - 1
+            container_key: FluidContainer
       annulus_temperature_table_a:
         columns:
           temperature_depth_a:
@@ -159,8 +161,6 @@ plugins:
       is_open_seabed_b: False
       annulus_depth_table_b:
         columns:
-          fluid_id_b:
-          - 2.0
           fluid_initial_measured_depth_b:
             values:
             - 0.0
@@ -169,6 +169,10 @@ plugins:
             values:
             - 2833.0
             unit: m
+          fluid_name_b:
+            plugin_item_ids:
+            - 2
+            container_key: FluidContainer
       annulus_temperature_table_b:
         columns:
           temperature_depth_b:
@@ -228,13 +232,15 @@ plugins:
       is_open_seabed_c: False
       annulus_depth_table_c:
         columns:
-          fluid_id_c: []
           fluid_initial_measured_depth_c:
             values: []
             unit: m
           fluid_final_measured_depth_c:
             values: []
             unit: m
+          fluid_name_c:
+            plugin_item_ids: []
+            container_key: FluidContainer
       annulus_temperature_table_c:
         columns:
           temperature_depth_c:
@@ -262,13 +268,15 @@ plugins:
       is_open_seabed_d: False
       annulus_depth_table_d:
         columns:
-          fluid_id_d: []
           fluid_initial_measured_depth_d:
             values: []
             unit: m
           fluid_final_measured_depth_d:
             values: []
             unit: m
+          fluid_name_d:
+            plugin_item_ids: []
+            container_key: FluidContainer
       annulus_temperature_table_d:
         columns:
           temperature_depth_d:
@@ -296,13 +304,15 @@ plugins:
       is_open_seabed_e: False
       annulus_depth_table_e:
         columns:
-          fluid_id_e: []
           fluid_initial_measured_depth_e:
             values: []
             unit: m
           fluid_final_measured_depth_e:
             values: []
             unit: m
+          fluid_name_e:
+            plugin_item_ids: []
+            container_key: FluidContainer
       annulus_temperature_table_e:
         columns:
           temperature_depth_e:

--- a/src/alfasim_score/converter/alfacase/_tests/test_convert_alfacase/test_create_alfacase_file_score_input_natural_flow_.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_convert_alfacase/test_create_alfacase_file_score_input_natural_flow_.alfacase
@@ -131,23 +131,25 @@ plugins:
             - 3906.79
             unit: m
           temperature_a:
-          - 4.44
-          - 5.216276362194144
-          - 45.102570507084444
-          - 45.933404962426266
-          - 46.763092625000326
-          - 47.59008242813707
-          - 48.41336681214941
-          - 49.23194273183265
-          - 50.04481287852061
-          - 50.8509868951526
-          - 51.649482582870945
-          - 52.439327097679005
-          - 53.219558135701675
-          - 53.98922510560453
-          - 54.74739028674283
-          - 55.47930539330239
-          - 105.99050193584353
+            values:
+            - 4.44
+            - 5.216276362194144
+            - 45.102570507084444
+            - 45.933404962426266
+            - 46.763092625000326
+            - 47.59008242813707
+            - 48.41336681214941
+            - 49.23194273183265
+            - 50.04481287852061
+            - 50.8509868951526
+            - 51.649482582870945
+            - 52.439327097679005
+            - 53.219558135701675
+            - 53.98922510560453
+            - 54.74739028674283
+            - 55.47930539330239
+            - 105.99050193584353
+            unit: degC
       has_fluid_return_a: True
       initial_leakoff_a:
         value: 0.0
@@ -196,23 +198,25 @@ plugins:
             - 3906.79
             unit: m
           temperature_b:
-          - 4.44
-          - 5.216276362194144
-          - 45.102570507084444
-          - 45.933404962426266
-          - 46.763092625000326
-          - 47.59008242813707
-          - 48.41336681214941
-          - 49.23194273183265
-          - 50.04481287852061
-          - 50.8509868951526
-          - 51.649482582870945
-          - 52.439327097679005
-          - 53.219558135701675
-          - 53.98922510560453
-          - 54.74739028674283
-          - 55.47930539330239
-          - 105.99050193584353
+            values:
+            - 4.44
+            - 5.216276362194144
+            - 45.102570507084444
+            - 45.933404962426266
+            - 46.763092625000326
+            - 47.59008242813707
+            - 48.41336681214941
+            - 49.23194273183265
+            - 50.04481287852061
+            - 50.8509868951526
+            - 51.649482582870945
+            - 52.439327097679005
+            - 53.219558135701675
+            - 53.98922510560453
+            - 54.74739028674283
+            - 55.47930539330239
+            - 105.99050193584353
+            unit: degC
       has_fluid_return_b: True
       initial_leakoff_b:
         value: 0.0
@@ -337,10 +341,13 @@ plugins:
       _children_list:
       - name: Brine_860
         fluid_type: PVT
+        pvt_table_content: Brine_860.tab
       - name: DFLT_FCBA_9.03
         fluid_type: PVT
+        pvt_table_content: DFLT_FCBA_9.03.tab
       - name: DFLT_FPBA_BARITE_8.60_35000
         fluid_type: PVT
+        pvt_table_content: DFLT_FPBA_BARITE_8.60_35000.tab
     MechanicalContainer:
       name: Mechanical Properties
       _children_list:
@@ -826,7 +833,7 @@ wells:
       top_of_filler:
         value: 0.0
         unit: m
-      filler_material: cement
+      filler_material: CM_cement
       material_above_filler: Brine_860
     - name: SURFACE_CASING_1
       hanger_depth:
@@ -851,7 +858,7 @@ wells:
       top_of_filler:
         value: 0.0
         unit: m
-      filler_material: cement
+      filler_material: CM_cement
       material_above_filler: Brine_860
     - name: PRODUCTION_CASING_1
       hanger_depth:
@@ -876,7 +883,7 @@ wells:
       top_of_filler:
         value: 1000.0
         unit: m
-      filler_material: cement
+      filler_material: CM_cement
       material_above_filler: DFLT_FPBA_BARITE_8.60_35000
     - name: PRODUCTION_CASING_2
       hanger_depth:
@@ -901,7 +908,7 @@ wells:
       top_of_filler:
         value: 2833.0
         unit: m
-      filler_material: cement
+      filler_material: CM_cement
       material_above_filler: DFLT_FPBA_BARITE_8.60_35000
     - name: PRODUCTION_CASING_3
       hanger_depth:
@@ -926,7 +933,7 @@ wells:
       top_of_filler:
         value: 3369.0
         unit: m
-      filler_material: cement
+      filler_material: CM_cement
       material_above_filler: DFLT_FPBA_BARITE_8.60_35000
     tubings:
     - name: TUBING_1
@@ -1340,7 +1347,7 @@ wells:
       start:
         value: 2072.0
         unit: m
-      material: Folhelho
+      material: FC_Folhelho
   top_node: WELLBORE_TOP_NODE
   bottom_node: WELLBORE_BOTTOM_NODE
   environment:

--- a/src/alfasim_score/converter/alfacase/_tests/test_convert_alfacase/test_create_alfacase_file_score_input_natural_flow_.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_convert_alfacase/test_create_alfacase_file_score_input_natural_flow_.alfacase
@@ -161,6 +161,9 @@ plugins:
       relief_position_a:
         value: 0.0
         unit: m
+      water_depth_pressure_a:
+        value: 0.0
+        unit: psi
       is_active_b: True
       mode_type_b: Undisturbed
       initial_top_pressure_b:
@@ -234,6 +237,9 @@ plugins:
       relief_position_b:
         value: -2072.0
         unit: m
+      water_depth_pressure_b:
+        value: 0.0
+        unit: psi
       is_active_c: False
       mode_type_c: Undisturbed
       initial_top_pressure_c:
@@ -270,6 +276,9 @@ plugins:
       relief_position_c:
         value: 0.0
         unit: m
+      water_depth_pressure_c:
+        value: 0.0
+        unit: psi
       is_active_d: False
       mode_type_d: Undisturbed
       initial_top_pressure_d:
@@ -306,6 +315,9 @@ plugins:
       relief_position_d:
         value: 0.0
         unit: m
+      water_depth_pressure_d:
+        value: 0.0
+        unit: psi
       is_active_e: False
       mode_type_e: Undisturbed
       initial_top_pressure_e:
@@ -342,6 +354,9 @@ plugins:
       relief_position_e:
         value: 0.0
         unit: m
+      water_depth_pressure_e:
+        value: 0.0
+        unit: psi
     FluidContainer:
       name: Annulus Fluids Container
       _children_list:

--- a/src/alfasim_score/converter/alfacase/_tests/test_convert_alfacase/test_create_alfacase_file_score_input_natural_flow_.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_convert_alfacase/test_create_alfacase_file_score_input_natural_flow_.alfacase
@@ -155,6 +155,12 @@ plugins:
         value: 0.0
         unit: m3
       has_pressure_relief_a: False
+      glv_delta_pressure_a:
+        value: 0.0
+        unit: psi
+      relief_position_a:
+        value: 0.0
+        unit: m
       is_active_b: True
       mode_type_b: Undisturbed
       initial_top_pressure_b:

--- a/src/alfasim_score/converter/alfacase/_tests/test_convert_base_alfacase/test_create_alfacase_base.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_convert_base_alfacase/test_create_alfacase_base.alfacase
@@ -413,7 +413,7 @@ wells:
       top_of_filler:
         value: 0.0
         unit: m
-      filler_material: cement
+      filler_material: CM_cement
       material_above_filler: Brine_860
     - name: SURFACE_CASING_1
       hanger_depth:
@@ -438,7 +438,7 @@ wells:
       top_of_filler:
         value: 0.0
         unit: m
-      filler_material: cement
+      filler_material: CM_cement
       material_above_filler: Brine_860
     - name: PRODUCTION_CASING_1
       hanger_depth:
@@ -463,7 +463,7 @@ wells:
       top_of_filler:
         value: 1000.0
         unit: m
-      filler_material: cement
+      filler_material: CM_cement
       material_above_filler: DFLT_FPBA_BARITE_8.60_35000
     - name: PRODUCTION_CASING_2
       hanger_depth:
@@ -488,7 +488,7 @@ wells:
       top_of_filler:
         value: 2833.0
         unit: m
-      filler_material: cement
+      filler_material: CM_cement
       material_above_filler: DFLT_FPBA_BARITE_8.60_35000
     - name: PRODUCTION_CASING_3
       hanger_depth:
@@ -513,7 +513,7 @@ wells:
       top_of_filler:
         value: 3369.0
         unit: m
-      filler_material: cement
+      filler_material: CM_cement
       material_above_filler: DFLT_FPBA_BARITE_8.60_35000
     tubings:
     - name: TUBING_1
@@ -919,7 +919,7 @@ wells:
       start:
         value: 2072.0
         unit: m
-      material: Folhelho
+      material: FC_Folhelho
   top_node: WELLBORE_TOP_NODE
   bottom_node: WELLBORE_BOTTOM_NODE
   environment:

--- a/src/alfasim_score/converter/alfacase/_tests/test_convert_base_alfacase/test_create_alfacase_base.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_convert_base_alfacase/test_create_alfacase_base.alfacase
@@ -1297,4 +1297,73 @@ materials:
   viscosity:
     value: 0.0
     unit: cP
+- name: Brine_860
+  material_type: fluid
+  density:
+    value: 1000.0
+    unit: kg/m3
+  thermal_conductivity:
+    value: 0.6
+    unit: W/m.K
+  heat_capacity:
+    value: 4181.0
+    unit: J/kg.K
+  inner_emissivity:
+    value: 0.0
+    unit: '-'
+  outer_emissivity:
+    value: 0.0
+    unit: '-'
+  expansion:
+    value: 0.0004
+    unit: 1/K
+  viscosity:
+    value: 0.0
+    unit: cP
+- name: DFLT_FCBA_9.00
+  material_type: fluid
+  density:
+    value: 1000.0
+    unit: kg/m3
+  thermal_conductivity:
+    value: 0.6
+    unit: W/m.K
+  heat_capacity:
+    value: 4181.0
+    unit: J/kg.K
+  inner_emissivity:
+    value: 0.0
+    unit: '-'
+  outer_emissivity:
+    value: 0.0
+    unit: '-'
+  expansion:
+    value: 0.0004
+    unit: 1/K
+  viscosity:
+    value: 0.0
+    unit: cP
+- name: DFLT_FPBA_BARITE_8.60_35000
+  material_type: fluid
+  density:
+    value: 1000.0
+    unit: kg/m3
+  thermal_conductivity:
+    value: 0.6
+    unit: W/m.K
+  heat_capacity:
+    value: 4181.0
+    unit: J/kg.K
+  inner_emissivity:
+    value: 0.0
+    unit: '-'
+  outer_emissivity:
+    value: 0.0
+    unit: '-'
+  expansion:
+    value: 0.0004
+    unit: 1/K
+  viscosity:
+    value: 0.0
+    unit: cP
 walls: []

--- a/src/alfasim_score/converter/alfacase/_tests/test_convert_base_alfacase/test_create_alfacase_base_operation_configuration.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_convert_base_alfacase/test_create_alfacase_base_operation_configuration.alfacase
@@ -430,9 +430,6 @@ pvt_models:
   default_model: base
   tables:
     base: DFLT_BLACK_OIL_27.40_230.00_1.17.tab
-    Brine_860: Brine_860.tab
-    DFLT_FCBA_9.00: DFLT_FCBA_9.00.tab
-    DFLT_FPBA_BARITE_8.60_35000: DFLT_FPBA_BARITE_8.60_35000.tab
 outputs:
   automatic_trend_frequency: True
   trends:

--- a/src/alfasim_score/converter/alfacase/_tests/test_convert_base_alfacase/test_create_alfacase_base_operation_configuration.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_convert_base_alfacase/test_create_alfacase_base_operation_configuration.alfacase
@@ -131,23 +131,25 @@ plugins:
             - 3906.79
             unit: m
           temperature_a:
-          - 4.44
-          - 5.216276362194144
-          - 45.102570507084444
-          - 45.933404962426266
-          - 46.763092625000326
-          - 47.59008242813707
-          - 48.41336681214941
-          - 49.23194273183265
-          - 50.04481287852061
-          - 50.8509868951526
-          - 51.649482582870945
-          - 52.439327097679005
-          - 53.219558135701675
-          - 53.98922510560453
-          - 54.74739028674283
-          - 55.47930539330239
-          - 105.99050193584353
+            values:
+            - 4.44
+            - 5.216276362194144
+            - 45.102570507084444
+            - 45.933404962426266
+            - 46.763092625000326
+            - 47.59008242813707
+            - 48.41336681214941
+            - 49.23194273183265
+            - 50.04481287852061
+            - 50.8509868951526
+            - 51.649482582870945
+            - 52.439327097679005
+            - 53.219558135701675
+            - 53.98922510560453
+            - 54.74739028674283
+            - 55.47930539330239
+            - 105.99050193584353
+            unit: degC
       has_fluid_return_a: True
       initial_leakoff_a:
         value: 0.0
@@ -196,23 +198,25 @@ plugins:
             - 3906.79
             unit: m
           temperature_b:
-          - 4.44
-          - 5.216276362194144
-          - 45.102570507084444
-          - 45.933404962426266
-          - 46.763092625000326
-          - 47.59008242813707
-          - 48.41336681214941
-          - 49.23194273183265
-          - 50.04481287852061
-          - 50.8509868951526
-          - 51.649482582870945
-          - 52.439327097679005
-          - 53.219558135701675
-          - 53.98922510560453
-          - 54.74739028674283
-          - 55.47930539330239
-          - 105.99050193584353
+            values:
+            - 4.44
+            - 5.216276362194144
+            - 45.102570507084444
+            - 45.933404962426266
+            - 46.763092625000326
+            - 47.59008242813707
+            - 48.41336681214941
+            - 49.23194273183265
+            - 50.04481287852061
+            - 50.8509868951526
+            - 51.649482582870945
+            - 52.439327097679005
+            - 53.219558135701675
+            - 53.98922510560453
+            - 54.74739028674283
+            - 55.47930539330239
+            - 105.99050193584353
+            unit: degC
       has_fluid_return_b: True
       initial_leakoff_b:
         value: 0.0
@@ -337,10 +341,13 @@ plugins:
       _children_list:
       - name: Brine_860
         fluid_type: PVT
+        pvt_table_content: Brine_860.tab
       - name: DFLT_FCBA_9.00
         fluid_type: PVT
+        pvt_table_content: DFLT_FCBA_9.00.tab
       - name: DFLT_FPBA_BARITE_8.60_35000
         fluid_type: PVT
+        pvt_table_content: DFLT_FPBA_BARITE_8.60_35000.tab
     MechanicalContainer:
       name: Mechanical Properties
       _children_list:
@@ -805,7 +812,7 @@ wells:
       top_of_filler:
         value: 0.0
         unit: m
-      filler_material: cement
+      filler_material: CM_cement
       material_above_filler: Brine_860
     - name: SURFACE_CASING_1
       hanger_depth:
@@ -830,7 +837,7 @@ wells:
       top_of_filler:
         value: 0.0
         unit: m
-      filler_material: cement
+      filler_material: CM_cement
       material_above_filler: Brine_860
     - name: PRODUCTION_CASING_1
       hanger_depth:
@@ -855,7 +862,7 @@ wells:
       top_of_filler:
         value: 1000.0
         unit: m
-      filler_material: cement
+      filler_material: CM_cement
       material_above_filler: DFLT_FPBA_BARITE_8.60_35000
     - name: PRODUCTION_CASING_2
       hanger_depth:
@@ -880,7 +887,7 @@ wells:
       top_of_filler:
         value: 2833.0
         unit: m
-      filler_material: cement
+      filler_material: CM_cement
       material_above_filler: DFLT_FPBA_BARITE_8.60_35000
     - name: PRODUCTION_CASING_3
       hanger_depth:
@@ -905,7 +912,7 @@ wells:
       top_of_filler:
         value: 3369.0
         unit: m
-      filler_material: cement
+      filler_material: CM_cement
       material_above_filler: DFLT_FPBA_BARITE_8.60_35000
     tubings:
     - name: TUBING_1
@@ -1311,7 +1318,7 @@ wells:
       start:
         value: 2072.0
         unit: m
-      material: Folhelho
+      material: FC_Folhelho
   top_node: WELLBORE_TOP_NODE
   bottom_node: WELLBORE_BOTTOM_NODE
   environment:

--- a/src/alfasim_score/converter/alfacase/_tests/test_convert_base_alfacase/test_create_alfacase_base_operation_configuration.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_convert_base_alfacase/test_create_alfacase_base_operation_configuration.alfacase
@@ -96,8 +96,6 @@ plugins:
       is_open_seabed_a: False
       annulus_depth_table_a:
         columns:
-          fluid_id_a:
-          - 1.0
           fluid_initial_measured_depth_a:
             values:
             - 0.0
@@ -106,6 +104,10 @@ plugins:
             values:
             - 3493.1800000000003
             unit: m
+          fluid_name_a:
+            plugin_item_ids:
+            - 1
+            container_key: FluidContainer
       annulus_temperature_table_a:
         columns:
           temperature_depth_a:
@@ -159,8 +161,6 @@ plugins:
       is_open_seabed_b: False
       annulus_depth_table_b:
         columns:
-          fluid_id_b:
-          - 2.0
           fluid_initial_measured_depth_b:
             values:
             - 0.0
@@ -169,6 +169,10 @@ plugins:
             values:
             - 2833.0
             unit: m
+          fluid_name_b:
+            plugin_item_ids:
+            - 2
+            container_key: FluidContainer
       annulus_temperature_table_b:
         columns:
           temperature_depth_b:
@@ -228,13 +232,15 @@ plugins:
       is_open_seabed_c: False
       annulus_depth_table_c:
         columns:
-          fluid_id_c: []
           fluid_initial_measured_depth_c:
             values: []
             unit: m
           fluid_final_measured_depth_c:
             values: []
             unit: m
+          fluid_name_c:
+            plugin_item_ids: []
+            container_key: FluidContainer
       annulus_temperature_table_c:
         columns:
           temperature_depth_c:
@@ -262,13 +268,15 @@ plugins:
       is_open_seabed_d: False
       annulus_depth_table_d:
         columns:
-          fluid_id_d: []
           fluid_initial_measured_depth_d:
             values: []
             unit: m
           fluid_final_measured_depth_d:
             values: []
             unit: m
+          fluid_name_d:
+            plugin_item_ids: []
+            container_key: FluidContainer
       annulus_temperature_table_d:
         columns:
           temperature_depth_d:
@@ -296,13 +304,15 @@ plugins:
       is_open_seabed_e: False
       annulus_depth_table_e:
         columns:
-          fluid_id_e: []
           fluid_initial_measured_depth_e:
             values: []
             unit: m
           fluid_final_measured_depth_e:
             values: []
             unit: m
+          fluid_name_e:
+            plugin_item_ids: []
+            container_key: FluidContainer
       annulus_temperature_table_e:
         columns:
           temperature_depth_e:

--- a/src/alfasim_score/converter/alfacase/_tests/test_convert_base_alfacase/test_create_alfacase_base_operation_configuration.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_convert_base_alfacase/test_create_alfacase_base_operation_configuration.alfacase
@@ -414,6 +414,10 @@ plugins:
         thermal_expansion_coefficient:
           value: 0.0
           unit: 1/K
+    Options:
+      name: Options
+      thermal_property_update_mode: First time step
+      is_gas_lift_on: True
   is_enabled: True
 pvt_models:
   default_model: base

--- a/src/alfasim_score/converter/alfacase/_tests/test_convert_base_alfacase/test_create_alfacase_base_operation_configuration.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_convert_base_alfacase/test_create_alfacase_base_operation_configuration.alfacase
@@ -1700,4 +1700,73 @@ materials:
   viscosity:
     value: 0.0
     unit: cP
+- name: Brine_860
+  material_type: fluid
+  density:
+    value: 1000.0
+    unit: kg/m3
+  thermal_conductivity:
+    value: 0.6
+    unit: W/m.K
+  heat_capacity:
+    value: 4181.0
+    unit: J/kg.K
+  inner_emissivity:
+    value: 0.0
+    unit: '-'
+  outer_emissivity:
+    value: 0.0
+    unit: '-'
+  expansion:
+    value: 0.0004
+    unit: 1/K
+  viscosity:
+    value: 0.0
+    unit: cP
+- name: DFLT_FCBA_9.00
+  material_type: fluid
+  density:
+    value: 1000.0
+    unit: kg/m3
+  thermal_conductivity:
+    value: 0.6
+    unit: W/m.K
+  heat_capacity:
+    value: 4181.0
+    unit: J/kg.K
+  inner_emissivity:
+    value: 0.0
+    unit: '-'
+  outer_emissivity:
+    value: 0.0
+    unit: '-'
+  expansion:
+    value: 0.0004
+    unit: 1/K
+  viscosity:
+    value: 0.0
+    unit: cP
+- name: DFLT_FPBA_BARITE_8.60_35000
+  material_type: fluid
+  density:
+    value: 1000.0
+    unit: kg/m3
+  thermal_conductivity:
+    value: 0.6
+    unit: W/m.K
+  heat_capacity:
+    value: 4181.0
+    unit: J/kg.K
+  inner_emissivity:
+    value: 0.0
+    unit: '-'
+  outer_emissivity:
+    value: 0.0
+    unit: '-'
+  expansion:
+    value: 0.0004
+    unit: 1/K
+  viscosity:
+    value: 0.0
+    unit: cP
 walls: []

--- a/src/alfasim_score/converter/alfacase/_tests/test_convert_base_alfacase/test_create_alfacase_base_operation_configuration.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_convert_base_alfacase/test_create_alfacase_base_operation_configuration.alfacase
@@ -161,6 +161,9 @@ plugins:
       relief_position_a:
         value: 0.0
         unit: m
+      water_depth_pressure_a:
+        value: 0.0
+        unit: psi
       is_active_b: True
       mode_type_b: Undisturbed
       initial_top_pressure_b:
@@ -234,6 +237,9 @@ plugins:
       relief_position_b:
         value: -2072.0
         unit: m
+      water_depth_pressure_b:
+        value: 0.0
+        unit: psi
       is_active_c: False
       mode_type_c: Undisturbed
       initial_top_pressure_c:
@@ -270,6 +276,9 @@ plugins:
       relief_position_c:
         value: 0.0
         unit: m
+      water_depth_pressure_c:
+        value: 0.0
+        unit: psi
       is_active_d: False
       mode_type_d: Undisturbed
       initial_top_pressure_d:
@@ -306,6 +315,9 @@ plugins:
       relief_position_d:
         value: 0.0
         unit: m
+      water_depth_pressure_d:
+        value: 0.0
+        unit: psi
       is_active_e: False
       mode_type_e: Undisturbed
       initial_top_pressure_e:
@@ -342,6 +354,9 @@ plugins:
       relief_position_e:
         value: 0.0
         unit: m
+      water_depth_pressure_e:
+        value: 0.0
+        unit: psi
     FluidContainer:
       name: Annulus Fluids Container
       _children_list:

--- a/src/alfasim_score/converter/alfacase/_tests/test_convert_base_alfacase/test_create_alfacase_base_operation_configuration.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_convert_base_alfacase/test_create_alfacase_base_operation_configuration.alfacase
@@ -155,6 +155,12 @@ plugins:
         value: 0.0
         unit: m3
       has_pressure_relief_a: False
+      glv_delta_pressure_a:
+        value: 0.0
+        unit: psi
+      relief_position_a:
+        value: 0.0
+        unit: m
       is_active_b: True
       mode_type_b: Undisturbed
       initial_top_pressure_b:

--- a/src/alfasim_score/converter/alfacase/_tests/test_convert_casing.py
+++ b/src/alfasim_score/converter/alfacase/_tests/test_convert_casing.py
@@ -3,40 +3,40 @@ from pytest_regressions.data_regression import DataRegressionFixture
 
 from alfasim_score.common import prepare_for_regression
 from alfasim_score.converter.alfacase.convert_alfacase import ScoreAlfacaseConverter
-from alfasim_score.converter.alfacase.score_input_reader import ScoreInputReader
+from alfasim_score.converter.alfacase.score_input_data import ScoreInputData
 
 
 def test_convert_casing_list(
     data_regression: DataRegressionFixture,
-    score_input_gas_lift: ScoreInputReader,
+    score_data_gas_lift: ScoreInputData,
 ) -> None:
-    builder = ScoreAlfacaseConverter(score_input_gas_lift)
+    builder = ScoreAlfacaseConverter(score_data_gas_lift)
     casings = builder._convert_casing_list()
     data_regression.check([prepare_for_regression(attr.asdict(casing)) for casing in casings])
 
 
 def test_convert_tubing_list(
     data_regression: DataRegressionFixture,
-    score_input_gas_lift: ScoreInputReader,
+    score_data_gas_lift: ScoreInputData,
 ) -> None:
-    builder = ScoreAlfacaseConverter(score_input_gas_lift)
+    builder = ScoreAlfacaseConverter(score_data_gas_lift)
     tubings = builder._convert_tubing_list()
     data_regression.check([prepare_for_regression(attr.asdict(tubing)) for tubing in tubings])
 
 
 def test_convert_packer_list(
     data_regression: DataRegressionFixture,
-    score_input_gas_lift: ScoreInputReader,
+    score_data_gas_lift: ScoreInputData,
 ) -> None:
-    builder = ScoreAlfacaseConverter(score_input_gas_lift)
+    builder = ScoreAlfacaseConverter(score_data_gas_lift)
     packers = builder._convert_packer_list()
     data_regression.check([prepare_for_regression(attr.asdict(packer)) for packer in packers])
 
 
 def test_convert_open_hole_list(
     data_regression: DataRegressionFixture,
-    score_input_gas_lift: ScoreInputReader,
+    score_data_gas_lift: ScoreInputData,
 ) -> None:
-    builder = ScoreAlfacaseConverter(score_input_gas_lift)
+    builder = ScoreAlfacaseConverter(score_data_gas_lift)
     open_holes = builder._convert_open_hole_list()
     data_regression.check([prepare_for_regression(attr.asdict(hole)) for hole in open_holes])

--- a/src/alfasim_score/converter/alfacase/_tests/test_convert_casing/test_convert_casing_list.yml
+++ b/src/alfasim_score/converter/alfacase/_tests/test_convert_casing/test_convert_casing_list.yml
@@ -1,4 +1,4 @@
-- filler_material: cement
+- filler_material: CM_cement
   hanger_depth:
     unit: m
     value: 0.0
@@ -23,7 +23,7 @@
   top_of_filler:
     unit: m
     value: 0.0
-- filler_material: cement
+- filler_material: CM_cement
   hanger_depth:
     unit: m
     value: 0.0
@@ -48,7 +48,7 @@
   top_of_filler:
     unit: m
     value: 0.0
-- filler_material: cement
+- filler_material: CM_cement
   hanger_depth:
     unit: m
     value: 0.0
@@ -73,7 +73,7 @@
   top_of_filler:
     unit: m
     value: 1000.0
-- filler_material: cement
+- filler_material: CM_cement
   hanger_depth:
     unit: m
     value: 1000.0
@@ -98,7 +98,7 @@
   top_of_filler:
     unit: m
     value: 2833.0
-- filler_material: cement
+- filler_material: CM_cement
   hanger_depth:
     unit: m
     value: 3369.0

--- a/src/alfasim_score/converter/alfacase/_tests/test_convert_formation.py
+++ b/src/alfasim_score/converter/alfacase/_tests/test_convert_formation.py
@@ -3,14 +3,14 @@ from pytest_regressions.data_regression import DataRegressionFixture
 
 from alfasim_score.common import prepare_for_regression
 from alfasim_score.converter.alfacase.convert_alfacase import ScoreAlfacaseConverter
-from alfasim_score.converter.alfacase.score_input_reader import ScoreInputReader
+from alfasim_score.converter.alfacase.score_input_data import ScoreInputData
 
 
 def test_convert_formation(
     data_regression: DataRegressionFixture,
-    score_input_gas_lift: ScoreInputReader,
+    score_data_gas_lift: ScoreInputData,
 ) -> None:
-    builder = ScoreAlfacaseConverter(score_input_gas_lift)
+    builder = ScoreAlfacaseConverter(score_data_gas_lift)
     formations = builder._convert_formation()
 
     data_regression.check(

--- a/src/alfasim_score/converter/alfacase/_tests/test_convert_formation/test_convert_formation.yml
+++ b/src/alfasim_score/converter/alfacase/_tests/test_convert_formation/test_convert_formation.yml
@@ -1,4 +1,4 @@
-- material: Folhelho
+- material: FC_Folhelho
   name: formation_1
   start:
     unit: m

--- a/src/alfasim_score/converter/alfacase/_tests/test_convert_materials.py
+++ b/src/alfasim_score/converter/alfacase/_tests/test_convert_materials.py
@@ -3,14 +3,14 @@ from pytest_regressions.data_regression import DataRegressionFixture
 
 from alfasim_score.common import prepare_for_regression
 from alfasim_score.converter.alfacase.convert_alfacase import ScoreAlfacaseConverter
-from alfasim_score.converter.alfacase.score_input_reader import ScoreInputReader
+from alfasim_score.converter.alfacase.score_input_data import ScoreInputData
 
 
 def test_convert_materials(
     data_regression: DataRegressionFixture,
-    score_input_gas_lift: ScoreInputReader,
+    score_data_gas_lift: ScoreInputData,
 ) -> None:
-    builder = ScoreAlfacaseConverter(score_input_gas_lift)
+    builder = ScoreAlfacaseConverter(score_data_gas_lift)
     materials = builder._convert_materials()
 
     data_regression.check([prepare_for_regression(attr.asdict(material)) for material in materials])

--- a/src/alfasim_score/converter/alfacase/_tests/test_convert_materials/test_convert_materials.yml
+++ b/src/alfasim_score/converter/alfacase/_tests/test_convert_materials/test_convert_materials.yml
@@ -182,3 +182,72 @@
   viscosity:
     unit: cP
     value: 0.0
+- density:
+    unit: kg/m3
+    value: 1000.0
+  expansion:
+    unit: 1/K
+    value: 0.0004
+  heat_capacity:
+    unit: J/kg.K
+    value: 4181.0
+  inner_emissivity:
+    unit: '-'
+    value: 0.0
+  material_type: fluid
+  name: Brine_860
+  outer_emissivity:
+    unit: '-'
+    value: 0.0
+  thermal_conductivity:
+    unit: W/m.K
+    value: 0.6
+  viscosity:
+    unit: cP
+    value: 0.0
+- density:
+    unit: kg/m3
+    value: 1000.0
+  expansion:
+    unit: 1/K
+    value: 0.0004
+  heat_capacity:
+    unit: J/kg.K
+    value: 4181.0
+  inner_emissivity:
+    unit: '-'
+    value: 0.0
+  material_type: fluid
+  name: DFLT_FCBA_9.00
+  outer_emissivity:
+    unit: '-'
+    value: 0.0
+  thermal_conductivity:
+    unit: W/m.K
+    value: 0.6
+  viscosity:
+    unit: cP
+    value: 0.0
+- density:
+    unit: kg/m3
+    value: 1000.0
+  expansion:
+    unit: 1/K
+    value: 0.0004
+  heat_capacity:
+    unit: J/kg.K
+    value: 4181.0
+  inner_emissivity:
+    unit: '-'
+    value: 0.0
+  material_type: fluid
+  name: DFLT_FPBA_BARITE_8.60_35000
+  outer_emissivity:
+    unit: '-'
+    value: 0.0
+  thermal_conductivity:
+    unit: W/m.K
+    value: 0.6
+  viscosity:
+    unit: cP
+    value: 0.0

--- a/src/alfasim_score/converter/alfacase/_tests/test_convert_well_environment.py
+++ b/src/alfasim_score/converter/alfacase/_tests/test_convert_well_environment.py
@@ -7,14 +7,14 @@ from pytest_regressions.data_regression import DataRegressionFixture
 from alfasim_score.common import prepare_for_regression
 from alfasim_score.constants import REFERENCE_VERTICAL_COORDINATE
 from alfasim_score.converter.alfacase.convert_alfacase import ScoreAlfacaseConverter
-from alfasim_score.converter.alfacase.score_input_reader import ScoreInputReader
+from alfasim_score.converter.alfacase.score_input_data import ScoreInputData
 
 
 def test_convert_well_environment(
     data_regression: DataRegressionFixture,
-    score_input_gas_lift: ScoreInputReader,
+    score_data_gas_lift: ScoreInputData,
 ) -> None:
-    builder = ScoreAlfacaseConverter(score_input_gas_lift)
+    builder = ScoreAlfacaseConverter(score_data_gas_lift)
     environment = builder._convert_well_environment()
 
     assert environment.thermal_model == PipeThermalModelType.SteadyState

--- a/src/alfasim_score/converter/alfacase/_tests/test_convert_well_trajectory.py
+++ b/src/alfasim_score/converter/alfacase/_tests/test_convert_well_trajectory.py
@@ -1,14 +1,14 @@
 from pytest_regressions.num_regression import NumericRegressionFixture
 
 from alfasim_score.converter.alfacase.convert_alfacase import ScoreAlfacaseConverter
-from alfasim_score.converter.alfacase.score_input_reader import ScoreInputReader
+from alfasim_score.converter.alfacase.score_input_data import ScoreInputData
 
 
 def test_convert_well_trajectory(
     num_regression: NumericRegressionFixture,
-    score_input_gas_lift: ScoreInputReader,
+    score_data_gas_lift: ScoreInputData,
 ) -> None:
-    builder = ScoreAlfacaseConverter(score_input_gas_lift)
+    builder = ScoreAlfacaseConverter(score_data_gas_lift)
     well_trajectory = builder._convert_well_trajectory()
     num_regression.check(
         {

--- a/src/alfasim_score/converter/alfacase/_tests/test_output_reader.py
+++ b/src/alfasim_score/converter/alfacase/_tests/test_output_reader.py
@@ -3,16 +3,17 @@ import pytest
 from pathlib import Path
 from pytest_regressions.num_regression import NumericRegressionFixture
 
+from alfasim_score.converter.alfacase.score_input_data import ScoreInputData
 from alfasim_score.converter.alfacase.score_input_reader import ScoreInputReader
 
 
 def test_output_reader(
     datadir: Path,
     num_regression: NumericRegressionFixture,
-    score_input_gas_lift: ScoreInputReader,
+    score_data_gas_lift: ScoreInputData,
 ) -> None:
     example_exported_filepath = datadir / "pressure_example.csv"
-    score_input_gas_lift.export_profile_curve(example_exported_filepath, "pressure")
+    score_data_gas_lift.export_profile_curve(example_exported_filepath, "pressure")
 
     results = pd.read_csv(example_exported_filepath)
     num_regression.check(

--- a/src/alfasim_score/converter/alfacase/_tests/test_output_results.py
+++ b/src/alfasim_score/converter/alfacase/_tests/test_output_results.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from pytest_mock import MockerFixture
 from pytest_regressions.file_regression import FileRegressionFixture
 
 from alfasim_score.common import AnnulusLabel
@@ -6,17 +7,23 @@ from alfasim_score.converter.alfacase.alfasim_score_converter import AlfasimScor
 
 
 def test_generate_output_file_results(
-    shared_datadir: Path, datadir: Path, file_regression: FileRegressionFixture
+    shared_datadir: Path,
+    datadir: Path,
+    file_regression: FileRegressionFixture,
+    mocker: MockerFixture,
 ) -> None:
     alfasim_results_path = shared_datadir / "case.data"
     # dummy input file just to have the reader for this test
     score_input_file = shared_datadir / "score_input_natural_flow.json"
     output_file = datadir / "output_score.json"
     converter = AlfasimScoreConverter(score_input_file, output_file)
+    mocker.patch.object(
+        converter.score_data,
+        "get_annuli_list",
+        return_value=[AnnulusLabel.A, AnnulusLabel.B, AnnulusLabel.C],
+    )
     # change the element name to match this test result well name
     converter.output_builder.element_name = "7-SRR-2-RJS (2022-07-28_15-01-27)"
-    # TODO: remember to get these annuli inside the output class
-    converter.output_builder.active_annuli = [AnnulusLabel.A, AnnulusLabel.B, AnnulusLabel.C]
     converter.generate_score_output_file(alfasim_results_path)
     output_content = converter.output_builder.score_output_filepath.read_text(encoding="utf-8")
     file_regression.check(output_content, extension=".json", encoding="utf-8")

--- a/src/alfasim_score/converter/alfacase/_tests/test_score_input_data.py
+++ b/src/alfasim_score/converter/alfacase/_tests/test_score_input_data.py
@@ -1,10 +1,9 @@
-import attr
+from barril.units import Scalar
 from pytest_regressions.data_regression import DataRegressionFixture
 
 from alfasim_score.common import AnnulusLabel
-from alfasim_score.common import prepare_for_regression
-from alfasim_score.converter.alfacase.convert_alfacase import ScoreAlfacaseConverter
 from alfasim_score.converter.alfacase.score_input_data import ScoreInputData
+from alfasim_score.units import PRESSURE_UNIT
 
 
 def test_get_annuli_list(
@@ -12,3 +11,9 @@ def test_get_annuli_list(
     score_data_gas_lift: ScoreInputData,
 ) -> None:
     assert score_data_gas_lift.get_annuli_list() == [AnnulusLabel.A, AnnulusLabel.B]
+
+
+def test_get_seabed_hydrostatic_pressure(
+    score_data_gas_lift: ScoreInputData,
+) -> None:
+    assert score_data_gas_lift.get_seabed_hydrostatic_pressure() == Scalar(20562115.0, "Pa")

--- a/src/alfasim_score/converter/alfacase/_tests/test_score_input_data.py
+++ b/src/alfasim_score/converter/alfacase/_tests/test_score_input_data.py
@@ -1,0 +1,14 @@
+import attr
+from pytest_regressions.data_regression import DataRegressionFixture
+
+from alfasim_score.common import AnnulusLabel
+from alfasim_score.common import prepare_for_regression
+from alfasim_score.converter.alfacase.convert_alfacase import ScoreAlfacaseConverter
+from alfasim_score.converter.alfacase.score_input_data import ScoreInputData
+
+
+def test_get_annuli_list(
+    data_regression: DataRegressionFixture,
+    score_data_gas_lift: ScoreInputData,
+) -> None:
+    assert score_data_gas_lift.get_annuli_list() == [AnnulusLabel.A, AnnulusLabel.B]

--- a/src/alfasim_score/converter/alfacase/alfasim_score_converter.py
+++ b/src/alfasim_score/converter/alfacase/alfasim_score_converter.py
@@ -6,6 +6,7 @@ from alfasim_score.common import OperationType
 from alfasim_score.converter.alfacase.base_operation import BaseOperationBuilder
 from alfasim_score.converter.alfacase.injection_operation import InjectionOperationBuilder
 from alfasim_score.converter.alfacase.production_operation import ProductionOperationBuilder
+from alfasim_score.converter.alfacase.score_input_data import ScoreInputData
 from alfasim_score.converter.alfacase.score_input_reader import ScoreInputReader
 from alfasim_score.converter.alfacase.score_output_generator import ScoreOutputBuilder
 
@@ -18,17 +19,18 @@ class AlfasimScoreConverter:
     """
 
     def __init__(self, score_input_file: Path, score_output_file: Path):
-        self.score_input = ScoreInputReader(score_input_file)
+        score_reader = ScoreInputReader(score_input_file)
+        self.score_data = ScoreInputData(score_reader)
         self.alfacase_builder = self._get_score_to_alfacase_builder()
-        self.output_builder = ScoreOutputBuilder(self.score_input, score_output_file)
+        self.output_builder = ScoreOutputBuilder(self.score_data, score_output_file)
 
     def _get_score_to_alfacase_builder(self) -> BaseOperationBuilder:
         """Convert SCORE input file to an alfacase description."""
-        operation_type = self.score_input.read_operation_type()
+        operation_type = self.score_data.operation_data["type"]
         if operation_type == OperationType.PRODUCTION:
-            return ProductionOperationBuilder(self.score_input)
+            return ProductionOperationBuilder(self.score_data)
         else:
-            return InjectionOperationBuilder(self.score_input)
+            return InjectionOperationBuilder(self.score_data)
 
     def generate_alfasim_input_file(self, alfacase_filepath: Path) -> None:
         """Create the ALFAsim input file (AKA alfacase) from an SCORE input file."""

--- a/src/alfasim_score/converter/alfacase/apb_plugin_data.py
+++ b/src/alfasim_score/converter/alfacase/apb_plugin_data.py
@@ -107,6 +107,7 @@ class Annulus:
     has_pressure_relief: bool = False
     pressure_relief: Scalar = Scalar(0.0, PRESSURE_UNIT)
     relief_position: Scalar = Scalar(0.0, LENGTH_UNIT)
+    water_depth_pressure: Scalar = Scalar(0.0, PRESSURE_UNIT)
 
     def to_dict(self, annulus_label: AnnulusLabel) -> Dict[str, Any]:
         """Convert data to dict in order to write data to the alfacase."""
@@ -116,8 +117,9 @@ class Annulus:
                 value = self.annulus_depth_table.to_dict(annulus_label)
             elif key == "annulus_temperature_table":
                 value = self.annulus_temperature_table.to_dict(annulus_label)
+            # pressure_relief for annulus A has a different name
             if f"{key}_{annulus_label.value}" == "pressure_relief_a":
-                output[f"glv_delta_pressure_a"] = value
+                output["glv_delta_pressure_a"] = value
                 continue
             output[f"{key}_{annulus_label.value}"] = value
         return output

--- a/src/alfasim_score/converter/alfacase/apb_plugin_data.py
+++ b/src/alfasim_score/converter/alfacase/apb_plugin_data.py
@@ -116,12 +116,10 @@ class Annulus:
                 value = self.annulus_depth_table.to_dict(annulus_label)
             elif key == "annulus_temperature_table":
                 value = self.annulus_temperature_table.to_dict(annulus_label)
+            if f"{key}_{annulus_label.value}" == "pressure_relief_a":
+                output[f"glv_delta_pressure_a"] = value
+                continue
             output[f"{key}_{annulus_label.value}"] = value
-
-        # the annular A doesn't have these parameters in plugin
-        if annulus_label == AnnulusLabel.A:
-            output.pop("pressure_relief_a")
-            output.pop("relief_position_a")
         return output
 
 

--- a/src/alfasim_score/converter/alfacase/apb_plugin_data.py
+++ b/src/alfasim_score/converter/alfacase/apb_plugin_data.py
@@ -148,7 +148,4 @@ class Options:
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert data to dict in order to write data to the alfacase."""
-        return {
-            "thermal_property_update_mode": self.thermal_property_update_mode,
-            "is_gas_lift_on": self.is_gas_lift_on,
-        }
+        return asdict(self)

--- a/src/alfasim_score/converter/alfacase/apb_plugin_data.py
+++ b/src/alfasim_score/converter/alfacase/apb_plugin_data.py
@@ -1,0 +1,154 @@
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Union
+
+from barril.units import Array
+from barril.units import Scalar
+from dataclasses import asdict
+from dataclasses import dataclass
+from dataclasses import field
+from enum import Enum
+
+from alfasim_score.common import AnnulusLabel
+from alfasim_score.common import AnnulusModeType
+from alfasim_score.common import FluidModelType
+from alfasim_score.units import LENGTH_UNIT
+from alfasim_score.units import PRESSURE_UNIT
+from alfasim_score.units import TEMPERATURE_UNIT
+from alfasim_score.units import VOLUME_UNIT
+
+
+class ThermalPropertyUpdateMode(str, Enum):
+    DISABLED = "Disabled"
+    FIRST_TIME_STEP = "First time step"
+    ALL_TIME_STEP = "All time steps"
+
+
+@dataclass
+class PluginReferences:
+    id_values: List[int]
+
+    def to_dict(self) -> Dict[str, Union[str, Scalar]]:
+        """Convert data to dict in order to write data to the alfacase."""
+        return {
+            "plugin_item_ids": self.id_values,
+            "container_key": "FluidContainer",
+        }
+
+
+@dataclass
+class FluidModelPvt:
+    name: str
+
+    def to_dict(self) -> Dict[str, Union[str, Scalar]]:
+        """Convert data to dict in order to write data to the alfacase."""
+        return {
+            "name": self.name,
+            "fluid_type": FluidModelType.PVT.value,
+            "pvt_table_content": f"{self.name}.tab",
+        }
+
+
+@dataclass
+class SolidMechanicalProperties:
+    name: str
+    young_modulus: Scalar
+    poisson_ratio: Scalar
+    thermal_expansion_coefficient: Scalar
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert data to dict in order to write data to the alfacase."""
+        return asdict(self)
+
+
+@dataclass
+class AnnulusDepthTable:
+    initial_depths: Array = field(default_factory=lambda: Array([], LENGTH_UNIT))
+    final_depths: Array = field(default_factory=lambda: Array([], LENGTH_UNIT))
+    fluid_references: PluginReferences = field(default_factory=lambda: PluginReferences([]))
+
+    def to_dict(self, annulus_label: AnnulusLabel) -> Dict[str, Any]:
+        """Convert data to dict in order to write data to the alfacase."""
+        columns = {
+            f"fluid_initial_measured_depth_{annulus_label.value}": self.initial_depths,
+            f"fluid_final_measured_depth_{annulus_label.value}": self.final_depths,
+            f"fluid_name_{annulus_label.value}": self.fluid_references.to_dict(),
+        }
+        return {"columns": columns}
+
+
+@dataclass
+class AnnulusTemperatureTable:
+    depths: Array = field(default_factory=lambda: Array([], LENGTH_UNIT))
+    temperatures: Array = field(default_factory=lambda: Array([], TEMPERATURE_UNIT))
+
+    def to_dict(self, annulus_label: AnnulusLabel) -> Dict[str, Any]:
+        """Convert data to dict in order to write data to the alfacase."""
+        columns = {
+            f"temperature_depth_{annulus_label.value}": self.depths,
+            f"temperature_{annulus_label.value}": self.temperatures,
+        }
+        return {"columns": columns}
+
+
+@dataclass
+class Annulus:
+    is_active: bool = False
+    mode_type: AnnulusModeType = AnnulusModeType.UNDISTURBED
+    initial_top_pressure: Scalar = Scalar(0.0, PRESSURE_UNIT)
+    is_open_seabed: bool = False
+    annulus_depth_table: AnnulusDepthTable = field(default_factory=lambda: AnnulusDepthTable())
+    annulus_temperature_table: AnnulusTemperatureTable = field(
+        default_factory=lambda: AnnulusTemperatureTable()
+    )
+    has_fluid_return: bool = False
+    initial_leakoff: Scalar = Scalar(0.0, VOLUME_UNIT)
+    has_pressure_relief: bool = False
+    pressure_relief: Scalar = Scalar(0.0, PRESSURE_UNIT)
+    relief_position: Scalar = Scalar(0.0, LENGTH_UNIT)
+
+    def to_dict(self, annulus_label: AnnulusLabel) -> Dict[str, Any]:
+        """Convert data to dict in order to write data to the alfacase."""
+        output = {}
+        for key, value in asdict(self).items():
+            if key == "annulus_depth_table":
+                value = self.annulus_depth_table.to_dict(annulus_label)
+            elif key == "annulus_temperature_table":
+                value = self.annulus_temperature_table.to_dict(annulus_label)
+            output[f"{key}_{annulus_label.value}"] = value
+
+        # the annular A doesn't have these parameters in plugin
+        if annulus_label == AnnulusLabel.A:
+            output.pop("pressure_relief_a")
+            output.pop("relief_position_a")
+        return output
+
+
+@dataclass
+class Annuli:
+    annulus_a: Annulus = field(default_factory=lambda: Annulus())
+    annulus_b: Annulus = field(default_factory=lambda: Annulus())
+    annulus_c: Annulus = field(default_factory=lambda: Annulus())
+    annulus_d: Annulus = field(default_factory=lambda: Annulus())
+    annulus_e: Annulus = field(default_factory=lambda: Annulus())
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert data to dict in order to write data to the alfacase."""
+        data = {}
+        for annulus_label in AnnulusLabel:
+            data.update(getattr(self, f"annulus_{annulus_label.value}").to_dict(annulus_label))
+        return data
+
+
+@dataclass
+class Options:
+    thermal_property_update_mode: ThermalPropertyUpdateMode
+    is_gas_lift_on: bool
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert data to dict in order to write data to the alfacase."""
+        return {
+            "thermal_property_update_mode": self.thermal_property_update_mode,
+            "is_gas_lift_on": self.is_gas_lift_on,
+        }

--- a/src/alfasim_score/converter/alfacase/base_operation.py
+++ b/src/alfasim_score/converter/alfacase/base_operation.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 from alfasim_sdk import CaseDescription
 from alfasim_sdk import CaseOutputDescription
 from alfasim_sdk import EnergyModel
@@ -37,6 +39,7 @@ from barril.units import Scalar
 from copy import deepcopy
 from pathlib import Path
 
+from alfasim_score.common import OperationType
 from alfasim_score.constants import GAS_LIFT_MASS_NODE_NAME
 from alfasim_score.constants import INITIAL_TIMESTEP
 from alfasim_score.constants import MAXIMUM_TIMESTEP
@@ -49,6 +52,7 @@ from alfasim_score.constants import WELLBORE_NAME
 from alfasim_score.constants import WELLBORE_TOP_NODE_NAME
 from alfasim_score.converter.alfacase.convert_alfacase import ScoreAlfacaseConverter
 from alfasim_score.converter.alfacase.convert_plugin_data import ScoreAPBPluginConverter
+from alfasim_score.converter.alfacase.score_input_data import ScoreInputData
 from alfasim_score.converter.alfacase.score_input_reader import ScoreInputReader
 from alfasim_score.units import FRACTION_UNIT
 from alfasim_score.units import LENGTH_UNIT
@@ -58,12 +62,13 @@ from alfasim_score.units import VELOCITY_UNIT
 
 
 class BaseOperationBuilder:
-    def __init__(self, score_input_reader: ScoreInputReader):
-        self.score_input = score_input_reader
-        self.alfacase_converter = ScoreAlfacaseConverter(self.score_input)
-        self.apb_plugin_converter = ScoreAPBPluginConverter(self.score_input)
-        self.base_alfacase = self.alfacase_converter.build_base_alfacase_description()
-        self.general_data = self.score_input.read_operation_data()
+    def __init__(self, score_input_data: ScoreInputData):
+        self.operation_type: Union[None, OperationType] = None
+        self.score_data = score_input_data
+        self.base_alfacase = ScoreAlfacaseConverter(
+            self.score_data
+        ).build_base_alfacase_description()
+        self.plugin_converters = [ScoreAPBPluginConverter(self.score_data)]
         self.default_output_profiles = [
             "elevation",
             "holdup",
@@ -89,17 +94,18 @@ class BaseOperationBuilder:
             "wall_5_temperature",
         ]
 
-    def _get_fluid_model_name(self) -> str:
-        """Get the name of the fluid model configured for this operation."""
-        return self.general_data["fluid"]
+    def assert_operation_type(self, operation: OperationType) -> None:
+        """Make sure the configured operation is the same of that configured in SCORE input."""
+        score_configured_operation = self.score_data.operation_data["type"]
+        assert (
+            operation == score_configured_operation
+        ), f"The created operation is production, but the imported operation is configured as {score_configured_operation}."
 
     def create_well_initial_pressures(
         self, top_pressure: Scalar, bottom_pressure: Scalar
     ) -> InitialPressuresDescription:
         """Create the initial pressures description."""
-        well_length = self.alfacase_converter.get_position_in_well(
-            self.score_input.read_general_data()["final_md"]
-        )
+        well_length = self.score_data.get_well_length()
         return InitialPressuresDescription(
             position_input_type=TableInputType.length,
             table_length=PressureContainerDescription(
@@ -115,9 +121,7 @@ class BaseOperationBuilder:
         self, top_temperature: Scalar, bottom_temperature: Scalar
     ) -> InitialTemperaturesDescription:
         """Create the initial temperatures description."""
-        well_length = self.alfacase_converter.get_position_in_well(
-            self.score_input.read_general_data()["final_md"]
-        )
+        well_length = self.score_data.get_well_length()
         return InitialTemperaturesDescription(
             position_input_type=TableInputType.length,
             table_length=TemperaturesContainerDescription(
@@ -150,9 +154,9 @@ class BaseOperationBuilder:
 
     def configure_pvt_model(self, alfacase: CaseDescription) -> None:
         """Configure the pvt fluid for the model."""
-        operation_fluid = self._get_fluid_model_name()
+        operation_fluid = self.score_data.operation_data["fluid"]
         tables = {"base": Path(f"{operation_fluid}.tab")}
-        fluid_names = self.apb_plugin_converter.get_all_annular_fluid_names()
+        fluid_names = self.score_data.get_all_annular_fluid_names()
         tables.update({name: Path(f"{name}.tab") for name in fluid_names})
         alfacase.pvt_models = PvtModelsDescription(
             default_model="base",
@@ -202,7 +206,7 @@ class BaseOperationBuilder:
     def configure_time_options(self, alfacase: CaseDescription) -> None:
         """Configure the description for the time options data."""
         alfacase.time_options = TimeOptionsDescription(
-            final_time=self.general_data["duration"],
+            final_time=self.score_data.operation_data["duration"],
             initial_timestep=INITIAL_TIMESTEP,
             minimum_timestep=MINIMUM_TIMESTEP,
             maximum_timestep=MAXIMUM_TIMESTEP,
@@ -221,7 +225,7 @@ class BaseOperationBuilder:
             NodeDescription(
                 name=WELLBORE_TOP_NODE_NAME,
                 node_type=NodeCellType.MassSource,
-                pvt_model=self._get_fluid_model_name(),
+                pvt_model=self.score_data.operation_data["fluid"],
                 mass_source_properties=MassSourceNodePropertiesDescription(
                     temperature_input_type=MultiInputType.Constant,
                     source_type=MassSourceType.AllVolumetricFlowRates,
@@ -235,7 +239,7 @@ class BaseOperationBuilder:
             NodeDescription(
                 name=WELLBORE_BOTTOM_NODE_NAME,
                 node_type=NodeCellType.Pressure,
-                pvt_model=self._get_fluid_model_name(),
+                pvt_model=self.score_data.operation_data["fluid"],
                 pressure_properties=PressureNodePropertiesDescription(
                     split_type=MassInflowSplitType.Pvt,
                 ),
@@ -243,7 +247,7 @@ class BaseOperationBuilder:
             NodeDescription(
                 name=GAS_LIFT_MASS_NODE_NAME,
                 node_type=NodeCellType.MassSource,
-                pvt_model=self._get_fluid_model_name(),
+                pvt_model=self.score_data.operation_data["fluid"],
                 mass_source_properties=MassSourceNodePropertiesDescription(
                     temperature_input_type=MultiInputType.Constant,
                     source_type=MassSourceType.AllVolumetricFlowRates,
@@ -263,12 +267,13 @@ class BaseOperationBuilder:
         """
         pass
 
-    def configure_apb_plugin_description(
+    def configure_plugin_descriptions(
         self,
         alfacase: CaseDescription,
     ) -> None:
-        """Configure the data for the apb plugin in the case description."""
-        alfacase.plugins.append(self.apb_plugin_converter.build_plugin_description())
+        """Configure in the case description the data for configured plugin list."""
+        for plugin_converter in self.plugin_converters:
+            alfacase.plugins.append(plugin_converter.build_plugin_description())
 
     def generate_operation_alfacase_description(self) -> CaseDescription:
         """Generate the configured alfacase description for the current operation."""
@@ -281,5 +286,5 @@ class BaseOperationBuilder:
         self.configure_nodes(alfacase_configured)
         self.configure_well_initial_conditions(alfacase_configured)
         self.configure_annulus(alfacase_configured)
-        self.configure_apb_plugin_description(alfacase_configured)
+        self.configure_plugin_descriptions(alfacase_configured)
         return alfacase_configured

--- a/src/alfasim_score/converter/alfacase/base_operation.py
+++ b/src/alfasim_score/converter/alfacase/base_operation.py
@@ -153,11 +153,13 @@ class BaseOperationBuilder:
         )
 
     def configure_pvt_model(self, alfacase: CaseDescription) -> None:
-        """Configure the pvt fluid for the model."""
+        """
+        Configure the pvt fluid for the model.
+        This method do not include the pvt tables provided by SCORE because they are
+        already used in the proper plugin section otherwise ALFAsim complains about duplication.
+        """
         operation_fluid = self.score_data.operation_data["fluid"]
         tables = {"base": Path(f"{operation_fluid}.tab")}
-        fluid_names = self.score_data.get_all_annular_fluid_names()
-        tables.update({name: Path(f"{name}.tab") for name in fluid_names})
         alfacase.pvt_models = PvtModelsDescription(
             default_model="base",
             tables=tables,

--- a/src/alfasim_score/converter/alfacase/convert_alfacase.py
+++ b/src/alfasim_score/converter/alfacase/convert_alfacase.py
@@ -74,7 +74,8 @@ class ScoreAlfacaseConverter:
             + self.score_data.reader.read_casing_materials()
             + self.score_data.reader.read_tubing_materials()
             + self.score_data.reader.read_lithology_materials()
-            + self.score_data.reader.read_packer_fluid()
+            + self.score_data.get_default_packer_fluid()
+            + self.score_data.get_default_fluid_properties()
         )
         for material in filter_duplicated_materials_by_name(material_list):
             material_descriptions.append(

--- a/src/alfasim_score/converter/alfacase/convert_alfacase.py
+++ b/src/alfasim_score/converter/alfacase/convert_alfacase.py
@@ -145,6 +145,7 @@ class ScoreAlfacaseConverter:
     def _convert_casing_list(self) -> List[CasingSectionDescription]:
         """Create the description for the casings."""
         casing_sections = []
+        cement = self.score_input.read_cement_material()[0]
         for casing in self.score_input.read_casings():
             for i, section in enumerate(casing["sections"], 1):
                 hanger_depth = self.get_position_in_well(section["top_md"])
@@ -164,7 +165,7 @@ class ScoreAlfacaseConverter:
                         inner_roughness=CASING_DEFAULT_ROUGHNESS,
                         material=section["material"],
                         top_of_filler=top_of_filler,
-                        filler_material=CEMENT_NAME,
+                        filler_material=cement["name"],
                         material_above_filler=casing["annular_fluids"][-1]["name"],
                     )
                 )

--- a/src/alfasim_score/converter/alfacase/convert_alfacase.py
+++ b/src/alfasim_score/converter/alfacase/convert_alfacase.py
@@ -37,7 +37,7 @@ from alfasim_score.constants import TUBING_DEFAULT_ROUGHNESS
 from alfasim_score.constants import WELLBORE_BOTTOM_NODE_NAME
 from alfasim_score.constants import WELLBORE_NAME
 from alfasim_score.constants import WELLBORE_TOP_NODE_NAME
-from alfasim_score.converter.alfacase.score_input_reader import ScoreInputReader
+from alfasim_score.converter.alfacase.score_input_data import ScoreInputData
 from alfasim_score.units import LENGTH_UNIT
 from alfasim_score.units import TEMPERATURE_UNIT
 
@@ -54,18 +54,8 @@ def get_section_top_of_filler(
 
 
 class ScoreAlfacaseConverter:
-    def __init__(self, score_input_reader: ScoreInputReader):
-        self.score_input = score_input_reader
-        self.general_data = score_input_reader.read_general_data()
-        self.well_start_position = self.general_data["water_depth"] + self.general_data["air_gap"]
-
-    def get_position_in_well(self, position: Scalar) -> Scalar:
-        """
-        Get the position relative to the well start position.
-        This method is a helper function to convert SCORE measured positions to the reference in well head
-        because this is the reference ALFAsim uses for well.
-        """
-        return position - self.well_start_position
+    def __init__(self, score_input_data: ScoreInputData):
+        self.score_data = score_input_data
 
     def _convert_well_trajectory(self) -> ProfileDescription:
         """
@@ -73,18 +63,18 @@ class ScoreAlfacaseConverter:
         NOTE: all positions don't start to count as zero at ANM, but they use the same values
         from the input SCORE file.
         """
-        trajectory = self.score_input.read_well_trajectory()
+        trajectory = self.score_data.reader.read_well_trajectory()
         return ProfileDescription(x_and_y=XAndYDescription(x=trajectory["x"], y=trajectory["y"]))
 
     def _convert_materials(self) -> List[MaterialDescription]:
         """Convert list of materials from SCORE file."""
         material_descriptions = []
         material_list = (
-            self.score_input.read_cement_material()
-            + self.score_input.read_casing_materials()
-            + self.score_input.read_tubing_materials()
-            + self.score_input.read_lithology_materials()
-            + self.score_input.read_packer_fluid()
+            self.score_data.reader.read_cement_material()
+            + self.score_data.reader.read_casing_materials()
+            + self.score_data.reader.read_tubing_materials()
+            + self.score_data.reader.read_lithology_materials()
+            + self.score_data.reader.read_packer_fluid()
         )
         for material in filter_duplicated_materials_by_name(material_list):
             material_descriptions.append(
@@ -105,11 +95,11 @@ class ScoreAlfacaseConverter:
             FormationLayerDescription(
                 name=f"formation_{i}",
                 start=convert_quota_to_tvd(
-                    formation["top_elevation"], self.general_data["air_gap"]
+                    formation["top_elevation"], self.score_data.general_data["air_gap"]
                 ),
                 material=formation["material"],
             )
-            for i, formation in enumerate(self.score_input.read_formations(), start=1)
+            for i, formation in enumerate(self.score_data.reader.read_formations(), start=1)
         ]
         return FormationDescription(
             reference_y_coordinate=REFERENCE_VERTICAL_COORDINATE, layers=layers
@@ -118,13 +108,13 @@ class ScoreAlfacaseConverter:
     def _convert_well_environment(self) -> EnvironmentDescription:
         """Create the description for the formations environment."""
         environment_description = []
-        temperature_profile = self.score_input.read_formation_temperatures()
+        temperature_profile = self.score_data.reader.read_formation_temperatures()
         for elevation, temperature in zip(
             temperature_profile["elevations"].GetValues(LENGTH_UNIT),
             temperature_profile["temperatures"].GetValues(TEMPERATURE_UNIT),
         ):
             depth_tvd = convert_quota_to_tvd(
-                Scalar(elevation, LENGTH_UNIT), self.general_data["air_gap"]
+                Scalar(elevation, LENGTH_UNIT), self.score_data.general_data["air_gap"]
             )
             temperature = Scalar(temperature, TEMPERATURE_UNIT)
             environment_description.append(
@@ -145,12 +135,12 @@ class ScoreAlfacaseConverter:
     def _convert_casing_list(self) -> List[CasingSectionDescription]:
         """Create the description for the casings."""
         casing_sections = []
-        cement = self.score_input.read_cement_material()[0]
-        for casing in self.score_input.read_casings():
+        cement = self.score_data.reader.read_cement_material()[0]
+        for casing in self.score_data.reader.read_casings():
             for i, section in enumerate(casing["sections"], 1):
-                hanger_depth = self.get_position_in_well(section["top_md"])
-                settings_depth = self.get_position_in_well(section["base_md"])
-                filler_depth = self.get_position_in_well(casing["top_of_cement"])
+                hanger_depth = self.score_data.get_position_in_well(section["top_md"])
+                settings_depth = self.score_data.get_position_in_well(section["base_md"])
+                filler_depth = self.score_data.get_position_in_well(casing["top_of_cement"])
                 top_of_filler = get_section_top_of_filler(
                     filler_depth, hanger_depth, settings_depth
                 )
@@ -175,7 +165,7 @@ class ScoreAlfacaseConverter:
     def _convert_tubing_list(self) -> List[TubingDescription]:
         """Create the description for the tubing list."""
         tubing_sections = []
-        for i, tubing in enumerate(self.score_input.read_tubing(), start=1):
+        for i, tubing in enumerate(self.score_data.reader.read_tubing(), start=1):
             tubing_sections.append(
                 TubingDescription(
                     name=f"TUBING_{i}",
@@ -190,9 +180,9 @@ class ScoreAlfacaseConverter:
 
     def _convert_packer_list(self) -> List[PackerDescription]:
         """Create the description for the packers."""
-        annular_fluid_data = self.score_input.read_tubing_fluid_data()
+        annular_fluid_data = self.score_data.reader.read_tubing_fluid_data()
         packers = []
-        for packer in self.score_input.read_packers():
+        for packer in self.score_data.reader.read_packers():
             # look for the material above packer
             # if not found, just use first fluid in annular fluids list
             material_above_name = annular_fluid_data[0]["name"]
@@ -205,7 +195,7 @@ class ScoreAlfacaseConverter:
             packers.append(
                 PackerDescription(
                     name=packer["name"],
-                    position=self.get_position_in_well(packer["position"]),
+                    position=self.score_data.get_position_in_well(packer["position"]),
                     material_above=material_above_name,
                 )
             )
@@ -215,11 +205,11 @@ class ScoreAlfacaseConverter:
         """Create the description for the open hole."""
         open_hole_list = []
         start_position = Scalar(
-            max([casing["shoe_md"].GetValue() for casing in self.score_input.read_casings()]),
+            max([casing["shoe_md"].GetValue() for casing in self.score_data.reader.read_casings()]),
             LENGTH_UNIT,
             "length",
         )
-        for i, open_hole in enumerate(self.score_input.read_open_hole(), start=1):
+        for i, open_hole in enumerate(self.score_data.reader.read_open_hole(), start=1):
             open_hole_list.append(
                 OpenHoleDescription(
                     name=f"OPEN_HOLE_{i}",
@@ -279,7 +269,7 @@ class ScoreAlfacaseConverter:
     def build_base_alfacase_description(self) -> CaseDescription:
         """Create the minimal alfacase description with well geometry/materials and the default nodes."""
         return CaseDescription(
-            name=self.general_data["case_name"],
+            name=self.score_data.general_data["case_name"],
             nodes=self._build_default_nodes(),
             wells=[self._build_well()],
             materials=self._convert_materials(),

--- a/src/alfasim_score/converter/alfacase/convert_plugin_data.py
+++ b/src/alfasim_score/converter/alfacase/convert_plugin_data.py
@@ -7,22 +7,23 @@ from alfasim_sdk import PluginDescription
 from barril.units import Array
 from barril.units import Scalar
 
-from alfasim_score.common import Annuli
-from alfasim_score.common import Annulus
-from alfasim_score.common import AnnulusDepthTable
-from alfasim_score.common import AnnulusTemperatureTable
-from alfasim_score.common import FluidModelPvt
 from alfasim_score.common import LiftMethod
-from alfasim_score.common import Options
-from alfasim_score.common import PluginReferences
-from alfasim_score.common import SolidMechanicalProperties
-from alfasim_score.common import ThermalPropertyUpdateMode
 from alfasim_score.common import WellItemFunction
 from alfasim_score.common import filter_duplicated_materials_by_name
 from alfasim_score.constants import ANNULUS_DEPTH_TOLERANCE
 from alfasim_score.constants import HAS_FLUID_RETURN
+from alfasim_score.converter.alfacase.apb_plugin_data import Annuli
+from alfasim_score.converter.alfacase.apb_plugin_data import Annulus
+from alfasim_score.converter.alfacase.apb_plugin_data import AnnulusDepthTable
+from alfasim_score.converter.alfacase.apb_plugin_data import AnnulusTemperatureTable
+from alfasim_score.converter.alfacase.apb_plugin_data import FluidModelPvt
+from alfasim_score.converter.alfacase.apb_plugin_data import Options
+from alfasim_score.converter.alfacase.apb_plugin_data import PluginReferences
+from alfasim_score.converter.alfacase.apb_plugin_data import SolidMechanicalProperties
+from alfasim_score.converter.alfacase.apb_plugin_data import ThermalPropertyUpdateMode
 from alfasim_score.converter.alfacase.score_input_reader import ScoreInputReader
 from alfasim_score.units import LENGTH_UNIT
+from alfasim_score.units import TEMPERATURE_UNIT
 
 
 class ScoreAPBPluginConverter:
@@ -75,11 +76,14 @@ class ScoreAPBPluginConverter:
         )
         formation_temperature_data = self.score_input.read_formation_temperatures()
         trajectory = self.score_input.read_well_trajectory()
-        interpolated_temperatures_y = np.interp(
-            np.abs(trajectory["y"]),
-            np.abs(formation_temperature_data["elevations"].GetValues())
-            + self.general_data["air_gap"].GetValue(),
-            formation_temperature_data["temperatures"].GetValues(),
+        interpolated_temperatures_y = Array(
+            np.interp(
+                np.abs(trajectory["y"]),
+                np.abs(formation_temperature_data["elevations"].GetValues())
+                + self.general_data["air_gap"].GetValue(),
+                formation_temperature_data["temperatures"].GetValues(),
+            ),
+            TEMPERATURE_UNIT,
         )
         return AnnulusTemperatureTable(
             depths=measured_depths, temperatures=interpolated_temperatures_y

--- a/src/alfasim_score/converter/alfacase/convert_plugin_data.py
+++ b/src/alfasim_score/converter/alfacase/convert_plugin_data.py
@@ -22,6 +22,7 @@ from alfasim_score.converter.alfacase.apb_plugin_data import ThermalPropertyUpda
 from alfasim_score.converter.alfacase.score_input_data import ScoreInputData
 from alfasim_score.converter.alfacase.score_input_reader import ScoreInputReader
 from alfasim_score.units import LENGTH_UNIT
+from alfasim_score.units import PRESSURE_UNIT
 from alfasim_score.units import TEMPERATURE_UNIT
 
 
@@ -127,6 +128,11 @@ class ScoreAPBPluginConverter:
                 casing = casings.pop()
                 if self.score_data.has_annular_fluid(casing["annular_fluids"]):
                     is_open_seabed = casing["function"] == WellItemFunction.SURFACE
+                    water_depth_pressure = (
+                        self.score_data.get_seabed_hydrostatic_pressure()
+                        if is_open_seabed
+                        else Scalar(0.0, PRESSURE_UNIT)
+                    )
                     setattr(
                         annuli,
                         f"annulus_{annulus_label}",
@@ -146,6 +152,7 @@ class ScoreAPBPluginConverter:
                             relief_position=self.score_data.get_position_in_well(
                                 casing["pressure_relief"]["position"]
                             ),
+                            water_depth_pressure=water_depth_pressure,
                         ),
                     )
         return annuli

--- a/src/alfasim_score/converter/alfacase/convert_plugin_data.py
+++ b/src/alfasim_score/converter/alfacase/convert_plugin_data.py
@@ -12,6 +12,7 @@ from alfasim_score.common import Annulus
 from alfasim_score.common import AnnulusDepthTable
 from alfasim_score.common import AnnulusTemperatureTable
 from alfasim_score.common import FluidModelPvt
+from alfasim_score.common import PluginReferences
 from alfasim_score.common import SolidMechanicalProperties
 from alfasim_score.common import WellItemFunction
 from alfasim_score.common import filter_duplicated_materials_by_name
@@ -80,22 +81,19 @@ class ScoreAPBPluginConverter:
         self, fluids_data: List[Dict[str, Any]]
     ) -> AnnulusDepthTable:
         """Build the table with fluids in the annular."""
-        fluid_names = []
-        fluid_ids = []
         initial_depths = []
         final_depths = []
+        fluid_ids = []
         for fluid in fluids_data:
             # in the SCORE input file when top and base measured distance are equal means that there is no fluid there
             if fluid["top_md"] < fluid["base_md"]:
-                fluid_names.append(fluid["name"])
-                fluid_ids.append(float(self.get_fluid_id(fluid["name"])))
                 initial_depths.append(self.get_position_in_well(fluid["top_md"]).GetValue())
                 final_depths.append(self.get_position_in_well(fluid["base_md"]).GetValue())
+                fluid_ids.append(int(self.get_fluid_id(fluid["name"])))
         return AnnulusDepthTable(
-            fluid_names,
-            fluid_ids,
             Array(initial_depths, LENGTH_UNIT),
             Array(final_depths, LENGTH_UNIT),
+            PluginReferences(fluid_ids),
         )
 
     def _has_annular_fluid(self, fluids_data: List[Dict[str, Any]]) -> bool:

--- a/src/alfasim_score/converter/alfacase/convert_plugin_data.py
+++ b/src/alfasim_score/converter/alfacase/convert_plugin_data.py
@@ -7,10 +7,8 @@ from alfasim_sdk import PluginDescription
 from barril.units import Array
 from barril.units import Scalar
 
-from alfasim_score.common import LiftMethod
 from alfasim_score.common import WellItemFunction
 from alfasim_score.common import filter_duplicated_materials_by_name
-from alfasim_score.constants import ANNULUS_DEPTH_TOLERANCE
 from alfasim_score.constants import HAS_FLUID_RETURN
 from alfasim_score.converter.alfacase.apb_plugin_data import Annuli
 from alfasim_score.converter.alfacase.apb_plugin_data import Annulus
@@ -21,45 +19,15 @@ from alfasim_score.converter.alfacase.apb_plugin_data import Options
 from alfasim_score.converter.alfacase.apb_plugin_data import PluginReferences
 from alfasim_score.converter.alfacase.apb_plugin_data import SolidMechanicalProperties
 from alfasim_score.converter.alfacase.apb_plugin_data import ThermalPropertyUpdateMode
+from alfasim_score.converter.alfacase.score_input_data import ScoreInputData
 from alfasim_score.converter.alfacase.score_input_reader import ScoreInputReader
 from alfasim_score.units import LENGTH_UNIT
 from alfasim_score.units import TEMPERATURE_UNIT
 
 
 class ScoreAPBPluginConverter:
-    def __init__(self, score_input_reader: ScoreInputReader):
-        self.score_input = score_input_reader
-        self.general_data = score_input_reader.read_general_data()
-        self.operation_data = score_input_reader.read_operation_data()
-        self.well_start_position = self.general_data["water_depth"] + self.general_data["air_gap"]
-
-    def has_gas_lift(self) -> bool:
-        """Check if the operation has gas lift."""
-        return self.operation_data.get("lift_method", "") == LiftMethod.GAS_LIFT
-
-    def get_position_in_well(self, position: Scalar) -> Scalar:
-        """
-        Get the position relative to the well start position.
-        This method is a helper function to convert SCORE measured positions to the reference in well head
-        because this is the reference ALFAsim uses for well.
-        """
-        return position - self.well_start_position
-
-    def get_all_annular_fluid_names(self) -> List[str]:
-        """Get the list of fluid names registered as annulus fluids in tubing and casing of SCORE data."""
-        all_fluids = set([fluid["name"] for fluid in self.score_input.read_tubing_fluid_data()])
-        for casings in self.score_input.read_casings():
-            for fluid in casings["annular_fluids"]:
-                all_fluids.add(fluid["name"])
-        return sorted(all_fluids)
-
-    def get_fluid_id(self, fluid_name: str) -> int:
-        """
-        Get the fluid id.
-        This method is used because the fluids need to have an id number because the fluid in the
-        plugin is identified by this number instead of its name.
-        """
-        return self.get_all_annular_fluid_names().index(fluid_name)
+    def __init__(self, score_input_data: ScoreInputData):
+        self.score_data = score_input_data
 
     def _build_annular_temperature_table(self) -> AnnulusTemperatureTable:
         """
@@ -69,18 +37,18 @@ class ScoreAPBPluginConverter:
         """
         measured_depths = Array(
             [
-                self.get_position_in_well(depth).GetValue()
-                for depth in self.score_input.read_well_trajectory()["md"]
+                self.score_data.get_position_in_well(depth).GetValue()
+                for depth in self.score_data.reader.read_well_trajectory()["md"]
             ],
             LENGTH_UNIT,
         )
-        formation_temperature_data = self.score_input.read_formation_temperatures()
-        trajectory = self.score_input.read_well_trajectory()
+        formation_temperature_data = self.score_data.reader.read_formation_temperatures()
+        trajectory = self.score_data.reader.read_well_trajectory()
         interpolated_temperatures_y = Array(
             np.interp(
                 np.abs(trajectory["y"]),
                 np.abs(formation_temperature_data["elevations"].GetValues())
-                + self.general_data["air_gap"].GetValue(),
+                + self.score_data.general_data["air_gap"].GetValue(),
                 formation_temperature_data["temperatures"].GetValues(),
             ),
             TEMPERATURE_UNIT,
@@ -99,22 +67,18 @@ class ScoreAPBPluginConverter:
         for fluid in fluids_data:
             # in the SCORE input file when top and base measured distance are equal means that there is no fluid there
             if fluid["top_md"] < fluid["base_md"]:
-                initial_depths.append(self.get_position_in_well(fluid["top_md"]).GetValue())
-                final_depths.append(self.get_position_in_well(fluid["base_md"]).GetValue())
-                fluid_ids.append(int(self.get_fluid_id(fluid["name"])))
+                initial_depths.append(
+                    self.score_data.get_position_in_well(fluid["top_md"]).GetValue()
+                )
+                final_depths.append(
+                    self.score_data.get_position_in_well(fluid["base_md"]).GetValue()
+                )
+                fluid_ids.append(int(self.score_data.get_fluid_id(fluid["name"])))
         return AnnulusDepthTable(
             Array(initial_depths, LENGTH_UNIT),
             Array(final_depths, LENGTH_UNIT),
             PluginReferences(fluid_ids),
         )
-
-    def _has_annular_fluid(self, fluids_data: List[Dict[str, Any]]) -> bool:
-        """
-        Check if there is fluid in the annular.
-        The current criterea is to use a threshold value of ANNULUS_DEPTH_TOLERANCE to define
-        if the annulus should be considered active.
-        """
-        return any([fluid["extension"] > ANNULUS_DEPTH_TOLERANCE for fluid in fluids_data])
 
     def _convert_annuli(self) -> Annuli:
         """
@@ -122,13 +86,13 @@ class ScoreAPBPluginConverter:
         """
         # It uses the data in list in the operation/thermal_data/annuli_data to define the A, B, C, D, E annulus
         # therefore it's considered here that they sorted in the input SCORE file.
-        annuli_data = self.score_input.read_operation_annuli_data().copy()
-        initial_conditions_data = self.score_input.read_initial_condition()
+        annuli_data = self.score_data.reader.read_operation_annuli_data().copy()
+        initial_conditions_data = self.score_data.reader.read_initial_condition()
         annular_temperature_table = self._build_annular_temperature_table()
         annuli = Annuli()
         if annuli_data:
             # the annulus A uses data from tubing_strings section of SCORE file
-            tubing_fluids_data = self.score_input.read_tubing_fluid_data()
+            tubing_fluids_data = self.score_data.reader.read_tubing_fluid_data()
             annulus_data = annuli_data.pop(0)
             annuli.annulus_a = Annulus(
                 is_active=True,
@@ -142,7 +106,9 @@ class ScoreAPBPluginConverter:
             )
 
         # create a list with the casings that are in the SCORE file
-        casings_data = {casing["function"]: casing for casing in self.score_input.read_casings()}
+        casings_data = {
+            casing["function"]: casing for casing in self.score_data.reader.read_casings()
+        }
         all_casing_types = [
             WellItemFunction.CONDUCTOR,
             WellItemFunction.SURFACE,
@@ -159,7 +125,7 @@ class ScoreAPBPluginConverter:
         for annulus_label, annulus_data in zip(["b", "c", "d", "e"], annuli_data):
             while casings:
                 casing = casings.pop()
-                if self._has_annular_fluid(casing["annular_fluids"]):
+                if self.score_data.has_annular_fluid(casing["annular_fluids"]):
                     is_open_seabed = casing["function"] == WellItemFunction.SURFACE
                     setattr(
                         annuli,
@@ -177,7 +143,7 @@ class ScoreAPBPluginConverter:
                             initial_leakoff=annulus_data["leakoff_volume"],
                             has_pressure_relief=casing["pressure_relief"]["is_active"],
                             pressure_relief=casing["pressure_relief"]["pressure"],
-                            relief_position=self.get_position_in_well(
+                            relief_position=self.score_data.get_position_in_well(
                                 casing["pressure_relief"]["position"]
                             ),
                         ),
@@ -188,10 +154,10 @@ class ScoreAPBPluginConverter:
         """Convert list of mechanical properties of solid materials from SCORE file."""
         solid_materials = []
         material_list = (
-            self.score_input.read_cement_material()
-            + self.score_input.read_casing_materials()
-            + self.score_input.read_tubing_materials()
-            + self.score_input.read_lithology_materials()
+            self.score_data.reader.read_cement_material()
+            + self.score_data.reader.read_casing_materials()
+            + self.score_data.reader.read_tubing_materials()
+            + self.score_data.reader.read_lithology_materials()
         )
         for material in filter_duplicated_materials_by_name(material_list):
             solid_materials.append(
@@ -207,12 +173,12 @@ class ScoreAPBPluginConverter:
     def _convert_fluids(self) -> List[FluidModelPvt]:
         """Convert the fluids used in the annuli."""
         # NOTE: for now the converter only uses PVT table model
-        return [FluidModelPvt(name) for name in self.get_all_annular_fluid_names()]
+        return [FluidModelPvt(name) for name in self.score_data.get_all_annular_fluid_names()]
 
     def _convert_options(self) -> Options:
         return Options(
             thermal_property_update_mode=ThermalPropertyUpdateMode.FIRST_TIME_STEP,
-            is_gas_lift_on=self.has_gas_lift(),
+            is_gas_lift_on=self.score_data.has_gas_lift(),
         )
 
     def build_plugin_description(self) -> PluginDescription:

--- a/src/alfasim_score/converter/alfacase/injection_operation.py
+++ b/src/alfasim_score/converter/alfacase/injection_operation.py
@@ -18,28 +18,26 @@ from alfasim_score.constants import NULL_VOLUMETRIC_FLOW_RATE
 from alfasim_score.constants import WELLBORE_BOTTOM_NODE_NAME
 from alfasim_score.constants import WELLBORE_TOP_NODE_NAME
 from alfasim_score.converter.alfacase.base_operation import BaseOperationBuilder
-from alfasim_score.converter.alfacase.score_input_reader import ScoreInputReader
+from alfasim_score.converter.alfacase.score_input_data import ScoreInputData
 from alfasim_score.units import FRACTION_UNIT
 from alfasim_score.units import TEMPERATURE_UNIT
 
 
 class InjectionOperationBuilder(BaseOperationBuilder):
-    def __init__(self, score_input_reader: ScoreInputReader):
-        super().__init__(score_input_reader)
+    def __init__(self, score_input_data: ScoreInputData):
+        super().__init__(score_input_data)
         self.operation_type = OperationType.INJECTION
-        assert (
-            self.general_data["type"] == self.operation_type
-        ), f"The created operation is injection, but the imported operation is configured as {self.general_data['type']}."
+        self.assert_operation_type(self.operation_type)
 
     def is_injecting(self, fluid_type: FluidType) -> bool:
         """Check if the operation has water or gas injected into the well."""
-        has_inlet_flow = self.general_data["flow_rate"].GetValue() > 0.0
-        return has_inlet_flow and self.general_data["fluid_type"] == fluid_type
+        has_inlet_flow = self.score_data.operation_data["flow_rate"].GetValue() > 0.0
+        return has_inlet_flow and self.score_data.operation_data["fluid_type"] == fluid_type
 
     def configure_well_initial_conditions(self, alfacase: CaseDescription) -> None:
         """Configure the well initial conditions with default values."""
         super().configure_well_initial_conditions(alfacase)
-        formation_data = self.score_input.read_formation_temperatures()
+        formation_data = self.score_data.reader.read_formation_temperatures()
         # once the simulation is configured as steady state regime for injection,
         # the expected value of injected phase is 1.0 when the steady state is reached
         gas_fraction = 1.0 if self.is_injecting(FluidType.GAS) else 0.0
@@ -48,8 +46,8 @@ class InjectionOperationBuilder(BaseOperationBuilder):
             alfacase.wells[0].initial_conditions,
             # the factor multiplied by the bottom pressure is arbitrary, just to set an initial value
             pressures=self.create_well_initial_pressures(
-                self.general_data["flow_initial_pressure"],
-                1.2 * self.general_data["flow_initial_pressure"],
+                self.score_data.operation_data["flow_initial_pressure"],
+                1.2 * self.score_data.operation_data["flow_initial_pressure"],
             ),
             volume_fractions=self.create_well_initial_volume_fractions(
                 Scalar(0.0, FRACTION_UNIT),
@@ -57,7 +55,7 @@ class InjectionOperationBuilder(BaseOperationBuilder):
                 Scalar(water_fraction, FRACTION_UNIT),
             ),
             temperatures=self.create_well_initial_temperatures(
-                self.general_data["flow_initial_temperature"],
+                self.score_data.operation_data["flow_initial_temperature"],
                 Scalar(formation_data["temperatures"][-1], TEMPERATURE_UNIT),
             ),
         )
@@ -71,11 +69,11 @@ class InjectionOperationBuilder(BaseOperationBuilder):
                 default_nodes.pop(WELLBORE_TOP_NODE_NAME),
                 node_type=NodeCellType.Pressure,
                 pressure_properties=PressureNodePropertiesDescription(
-                    temperature=self.general_data["flow_initial_temperature"],
-                    pressure=self.general_data["flow_initial_pressure"],
+                    temperature=self.score_data.operation_data["flow_initial_temperature"],
+                    pressure=self.score_data.operation_data["flow_initial_pressure"],
                     split_type=MassInflowSplitType.Pvt,
                 ),
-                pvt_model=self._get_fluid_model_name(),
+                pvt_model=self.score_data.operation_data["fluid"],
             ),
             attr.evolve(
                 default_nodes.pop(WELLBORE_BOTTOM_NODE_NAME),
@@ -85,19 +83,19 @@ class InjectionOperationBuilder(BaseOperationBuilder):
                     source_type=MassSourceType.AllVolumetricFlowRates,
                     volumetric_flow_rates_std={
                         FLUID_GAS: (
-                            -1.0 * self.general_data["flow_rate"]
+                            -1.0 * self.score_data.operation_data["flow_rate"]
                             if self.is_injecting(FluidType.GAS)
                             else NULL_VOLUMETRIC_FLOW_RATE
                         ),
                         FLUID_OIL: NULL_VOLUMETRIC_FLOW_RATE,
                         FLUID_WATER: (
-                            -1.0 * self.general_data["flow_rate"]
+                            -1.0 * self.score_data.operation_data["flow_rate"]
                             if self.is_injecting(FluidType.WATER)
                             else NULL_VOLUMETRIC_FLOW_RATE
                         ),
                     },
                 ),
-                pvt_model=self._get_fluid_model_name(),
+                pvt_model=self.score_data.operation_data["fluid"],
             ),
         ]
         # just use the original gas lift node with zero flow rate

--- a/src/alfasim_score/converter/alfacase/score_input_data.py
+++ b/src/alfasim_score/converter/alfacase/score_input_data.py
@@ -45,8 +45,7 @@ class ScoreInputData:
         This method is a helper function to convert SCORE measured positions to the reference in well head
         because this is the reference ALFAsim uses for well.
         """
-        well_start_position = self.general_data["water_depth"] + self.general_data["air_gap"]
-        return position - well_start_position
+        return position - self.get_well_start_position()
 
     def get_all_annular_fluid_names(self) -> List[str]:
         """Get the list of fluid names registered as annulus fluids in tubing and casing of SCORE data."""

--- a/src/alfasim_score/converter/alfacase/score_input_data.py
+++ b/src/alfasim_score/converter/alfacase/score_input_data.py
@@ -13,6 +13,7 @@ from alfasim_score.constants import ANNULUS_DEPTH_TOLERANCE
 from alfasim_score.constants import FLUID_DEFAULT_NAME
 from alfasim_score.converter.alfacase.score_input_reader import ScoreInputReader
 from alfasim_score.units import LENGTH_UNIT
+from alfasim_score.units import PRESSURE_UNIT
 from alfasim_score.units import SPECIFIC_HEAT_UNIT
 from alfasim_score.units import THERMAL_CONDUCTIVITY_UNIT
 from alfasim_score.units import THERMAL_EXPANSION_UNIT
@@ -117,3 +118,10 @@ class ScoreInputData:
                             curve_name: value,
                         }
                     )
+
+    def get_seabed_hydrostatic_pressure(self) -> Scalar:
+        """Calculate the value of hydrostatic pressure at seabed position."""
+        rho = 1025  # kg/m3
+        g = 9.8  # m/s²
+        h = self.general_data["water_depth"].GetValue(LENGTH_UNIT)
+        return Scalar(rho * g * h, "Pa")

--- a/src/alfasim_score/converter/alfacase/score_input_data.py
+++ b/src/alfasim_score/converter/alfacase/score_input_data.py
@@ -71,6 +71,16 @@ class ScoreInputData:
         total_annuli = len(annuli_data)
         return list(AnnulusLabel)[:total_annuli]
 
+    def _get_default_fluid(self, fluid_name: str) -> Dict[str, Union[Scalar, str]]:
+        return {
+            "name": fluid_name,
+            "type": "fluid",
+            "density": Scalar(1000.0, "kg/m3", "density"),
+            "thermal_conductivity": Scalar(0.6, THERMAL_CONDUCTIVITY_UNIT),
+            "specific_heat": Scalar(4181.0, SPECIFIC_HEAT_UNIT),
+            "thermal_expansion": Scalar(0.0004, THERMAL_EXPANSION_UNIT),
+        }
+
     def get_default_fluid_properties(self) -> List[Dict[str, Union[Scalar, str]]]:
         """
         Get default properties for the materials that must be filled for material list
@@ -78,26 +88,9 @@ class ScoreInputData:
         The properties here are for now the same of default packer fluid
         """
         return [
-            {
-                "name": fluid_name,
-                "type": "fluid",
-                "density": Scalar(1000.0, "kg/m3", "density"),
-                "thermal_conductivity": Scalar(0.6, THERMAL_CONDUCTIVITY_UNIT),
-                "specific_heat": Scalar(4181.0, SPECIFIC_HEAT_UNIT),
-                "thermal_expansion": Scalar(0.0004, THERMAL_EXPANSION_UNIT),
-            }
-            for fluid_name in self.get_all_annular_fluid_names()
+            self._get_default_fluid(fluid_name) for fluid_name in self.get_all_annular_fluid_names()
         ]
 
     def get_default_packer_fluid(self) -> List[Dict[str, Union[Scalar, str]]]:
         """Get the properties of default fluid above packer."""
-        return [
-            {
-                "name": FLUID_DEFAULT_NAME,
-                "type": "fluid",
-                "density": Scalar(1000.0, "kg/m3", "density"),
-                "thermal_conductivity": Scalar(0.6, THERMAL_CONDUCTIVITY_UNIT),
-                "specific_heat": Scalar(4181.0, SPECIFIC_HEAT_UNIT),
-                "thermal_expansion": Scalar(0.0004, THERMAL_EXPANSION_UNIT),
-            }
-        ]
+        return [self._get_default_fluid(FLUID_DEFAULT_NAME)]

--- a/src/alfasim_score/converter/alfacase/score_input_data.py
+++ b/src/alfasim_score/converter/alfacase/score_input_data.py
@@ -1,13 +1,18 @@
 from typing import Any
 from typing import Dict
 from typing import List
+from typing import Union
 
 from barril.units import Scalar
 
 from alfasim_score.common import AnnulusLabel
 from alfasim_score.common import LiftMethod
 from alfasim_score.constants import ANNULUS_DEPTH_TOLERANCE
+from alfasim_score.constants import FLUID_DEFAULT_NAME
 from alfasim_score.converter.alfacase.score_input_reader import ScoreInputReader
+from alfasim_score.units import SPECIFIC_HEAT_UNIT
+from alfasim_score.units import THERMAL_CONDUCTIVITY_UNIT
+from alfasim_score.units import THERMAL_EXPANSION_UNIT
 
 
 class ScoreInputData:
@@ -65,3 +70,34 @@ class ScoreInputData:
         annuli_data = self.reader.read_operation_annuli_data()
         total_annuli = len(annuli_data)
         return list(AnnulusLabel)[:total_annuli]
+
+    def get_default_fluid_properties(self) -> List[Dict[str, Union[Scalar, str]]]:
+        """
+        Get default properties for the materials that must be filled for material list
+        of alfacase regardless their properties are being calculated from pvt table in the plugin.
+        The properties here are for now the same of default packer fluid
+        """
+        return [
+            {
+                "name": fluid_name,
+                "type": "fluid",
+                "density": Scalar(1000.0, "kg/m3", "density"),
+                "thermal_conductivity": Scalar(0.6, THERMAL_CONDUCTIVITY_UNIT),
+                "specific_heat": Scalar(4181.0, SPECIFIC_HEAT_UNIT),
+                "thermal_expansion": Scalar(0.0004, THERMAL_EXPANSION_UNIT),
+            }
+            for fluid_name in self.get_all_annular_fluid_names()
+        ]
+
+    def get_default_packer_fluid(self) -> List[Dict[str, Union[Scalar, str]]]:
+        """Get the properties of default fluid above packer."""
+        return [
+            {
+                "name": FLUID_DEFAULT_NAME,
+                "type": "fluid",
+                "density": Scalar(1000.0, "kg/m3", "density"),
+                "thermal_conductivity": Scalar(0.6, THERMAL_CONDUCTIVITY_UNIT),
+                "specific_heat": Scalar(4181.0, SPECIFIC_HEAT_UNIT),
+                "thermal_expansion": Scalar(0.0004, THERMAL_EXPANSION_UNIT),
+            }
+        ]

--- a/src/alfasim_score/converter/alfacase/score_input_data.py
+++ b/src/alfasim_score/converter/alfacase/score_input_data.py
@@ -1,0 +1,67 @@
+from typing import Any
+from typing import Dict
+from typing import List
+
+from barril.units import Scalar
+
+from alfasim_score.common import AnnulusLabel
+from alfasim_score.common import LiftMethod
+from alfasim_score.constants import ANNULUS_DEPTH_TOLERANCE
+from alfasim_score.converter.alfacase.score_input_reader import ScoreInputReader
+
+
+class ScoreInputData:
+    def __init__(self, score_input_reader: ScoreInputReader):
+        self.reader = score_input_reader
+        self.general_data = self.reader.read_general_data()
+        self.operation_data = self.reader.read_operation_data()
+
+    def has_gas_lift(self) -> bool:
+        """Check if the operation has gas lift."""
+        return self.operation_data.get("lift_method", "") == LiftMethod.GAS_LIFT
+
+    def has_annular_fluid(self, fluids_data: List[Dict[str, Any]]) -> bool:
+        """
+        Check if there is fluid in the annular.
+        The current criterea is to use a threshold value of ANNULUS_DEPTH_TOLERANCE to define
+        if the annulus should be considered active.
+        """
+        return any([fluid["extension"] > ANNULUS_DEPTH_TOLERANCE for fluid in fluids_data])
+
+    def get_well_start_position(self) -> Scalar:
+        return self.general_data["water_depth"] + self.general_data["air_gap"]
+
+    def get_position_in_well(self, position: Scalar) -> Scalar:
+        """
+        Get the position relative to the well start position.
+        This method is a helper function to convert SCORE measured positions to the reference in well head
+        because this is the reference ALFAsim uses for well.
+        """
+        well_start_position = self.general_data["water_depth"] + self.general_data["air_gap"]
+        return position - well_start_position
+
+    def get_all_annular_fluid_names(self) -> List[str]:
+        """Get the list of fluid names registered as annulus fluids in tubing and casing of SCORE data."""
+        all_fluids = set([fluid["name"] for fluid in self.reader.read_tubing_fluid_data()])
+        for casings in self.reader.read_casings():
+            for fluid in casings["annular_fluids"]:
+                all_fluids.add(fluid["name"])
+        return sorted(all_fluids)
+
+    def get_fluid_id(self, fluid_name: str) -> int:
+        """
+        Get the fluid id.
+        This method is used because the fluids need to have an id number because the fluid in the
+        plugin is identified by this number instead of its name.
+        """
+        return self.get_all_annular_fluid_names().index(fluid_name)
+
+    def get_well_length(self) -> Scalar:
+        """Calculate the well length configured in SCORE file."""
+        return self.get_position_in_well(self.reader.read_general_data()["final_md"])
+
+    def get_annuli_list(self) -> List[AnnulusLabel]:
+        """Get the list of active annuli configured in the input file"""
+        annuli_data = self.reader.read_operation_annuli_data()
+        total_annuli = len(annuli_data)
+        return list(AnnulusLabel)[:total_annuli]

--- a/src/alfasim_score/converter/alfacase/score_input_reader.py
+++ b/src/alfasim_score/converter/alfacase/score_input_reader.py
@@ -36,6 +36,14 @@ from alfasim_score.units import VOLUME_UNIT
 from alfasim_score.units import YOUNG_MODULUS_UNIT
 
 
+def encode_formation_name(name: str) -> str:
+    return FORMATION_PREFIX + name
+
+
+def encode_cement_name(name: str) -> str:
+    return CEMENT_PREFIX + name
+
+
 class ScoreInputReader:
     def __init__(self, score_filepath: Path):
         self.score_filepath = score_filepath
@@ -119,7 +127,7 @@ class ScoreInputReader:
         properties = well_strings[0]["cementing"]["first_slurry"]["thermomechanical_property"]
         return [
             {
-                "name": CEMENT_PREFIX + CEMENT_NAME,
+                "name": encode_cement_name(CEMENT_NAME),
                 "type": "solid",
                 "density": Scalar(properties["density"], DENSITY_UNIT),
                 "thermal_conductivity": Scalar(
@@ -141,7 +149,7 @@ class ScoreInputReader:
             properties = lithology["thermomechanical_property"]
             lithology_data.append(
                 {
-                    "name": FORMATION_PREFIX + lithology["display_name"],
+                    "name": encode_formation_name(lithology["display_name"]),
                     "type": "solid",
                     "density": Scalar(properties["density"], DENSITY_UNIT),
                     "thermal_conductivity": Scalar(
@@ -270,7 +278,7 @@ class ScoreInputReader:
         """Read data for formations from SCORE input file."""
         return [
             {
-                "material": lithology["display_name"],
+                "material": encode_formation_name(lithology["display_name"]),
                 # elevations are given in quota
                 "top_elevation": Scalar(lithology["top_elevation"], LENGTH_UNIT, "length"),
                 "base_elevation": Scalar(lithology["base_elevation"], LENGTH_UNIT, "length"),

--- a/src/alfasim_score/converter/alfacase/score_input_reader.py
+++ b/src/alfasim_score/converter/alfacase/score_input_reader.py
@@ -3,7 +3,6 @@ from typing import Dict
 from typing import List
 from typing import Union
 
-import csv
 import json
 from barril.units import Array
 from barril.units import Scalar
@@ -411,24 +410,3 @@ class ScoreInputReader:
                 ),
             }
         return {}
-
-    def export_profile_curve(self, filepath: Path, curve_name: str) -> None:
-        """
-        Export the result of a curve to a file.
-        This function export the measured depth related to the well start positions.
-        The exported output file is used to check cases results.
-        """
-        curves = self.read_output_curves()
-        if len(curves):
-            general_data = self.read_general_data()
-            start_position = general_data["water_depth"] + general_data["air_gap"]
-            with open(filepath, "w", encoding="utf-8") as csv_file:
-                writer = csv.DictWriter(csv_file, fieldnames=["measured_depth", curve_name])
-                writer.writeheader()
-                for md, value in zip(curves["measured_depth"], curves[curve_name]):
-                    writer.writerow(
-                        {
-                            "measured_depth": md - start_position.GetValue(LENGTH_UNIT),
-                            curve_name: value,
-                        }
-                    )

--- a/src/alfasim_score/converter/alfacase/score_input_reader.py
+++ b/src/alfasim_score/converter/alfacase/score_input_reader.py
@@ -399,6 +399,9 @@ class ScoreInputReader:
         ]
 
     def read_initial_condition(self) -> Dict[str, AnnulusModeType]:
+        """
+        Get the initial condition data from the input file.
+        """
         initial_conditions_data = self.input_content["initial_conditions"][0]
         return {"mode": AnnulusModeType(initial_conditions_data["reference"])}
 

--- a/src/alfasim_score/converter/alfacase/score_input_reader.py
+++ b/src/alfasim_score/converter/alfacase/score_input_reader.py
@@ -18,7 +18,6 @@ from alfasim_score.common import WellItemFunction
 from alfasim_score.common import WellItemType
 from alfasim_score.constants import CEMENT_NAME
 from alfasim_score.constants import CEMENT_PREFIX
-from alfasim_score.constants import FLUID_DEFAULT_NAME
 from alfasim_score.constants import FORMATION_PREFIX
 from alfasim_score.units import DENSITY_UNIT
 from alfasim_score.units import DIAMETER_UNIT
@@ -163,19 +162,6 @@ class ScoreInputReader:
                 }
             )
         return lithology_data
-
-    def read_packer_fluid(self) -> List[Dict[str, Union[Scalar, str]]]:
-        """Get the properties of default fluid above packer."""
-        return [
-            {
-                "name": FLUID_DEFAULT_NAME,
-                "type": "fluid",
-                "density": Scalar(1000.0, "kg/m3", "density"),
-                "thermal_conductivity": Scalar(0.6, THERMAL_CONDUCTIVITY_UNIT),
-                "specific_heat": Scalar(4181.0, SPECIFIC_HEAT_UNIT),
-                "thermal_expansion": Scalar(0.0004, THERMAL_EXPANSION_UNIT),
-            }
-        ]
 
     def read_casings(self) -> List[Dict[str, Any]]:
         """Read the data for the casing from SCORE input file."""

--- a/src/alfasim_score/converter/alfacase/score_output_generator.py
+++ b/src/alfasim_score/converter/alfacase/score_output_generator.py
@@ -24,9 +24,7 @@ class ScoreOutputBuilder:
         self.score_output_filepath = score_output_filepath
         self.element_name = WELLBORE_NAME
 
-    def _generate_annuli_output(
-        self, results: Results, measured_depths: np.ndarray
-    ) -> Dict[str, Any]:
+    def _generate_annuli_output(self, results: Results, measured_depths: List) -> Dict[str, Any]:
         """Create data for the output results of annuli."""
         active_annuli = self.score_data.get_annuli_list()
         annuli_temperature_profiles = [
@@ -41,7 +39,7 @@ class ScoreOutputBuilder:
             annuli_temperature_profiles, annuli_pressure_profiles
         ):
             annuli_output[str(annulus_index)] = {}
-            annuli_output[str(annulus_index)]["MD"] = measured_depths.tolist()
+            annuli_output[str(annulus_index)]["MD"] = measured_depths
             temperature = {}
             temperature["start"] = (
                 results.get_profile_curve(temperature_profile_name, self.element_name, 0)
@@ -89,9 +87,7 @@ class ScoreOutputBuilder:
         }
         return production_tubing
 
-    def _generate_walls_output(
-        self, results: Results, measured_depths: np.ndarray
-    ) -> Dict[str, Any]:
+    def _generate_walls_output(self, results: Results, measured_depths: List) -> Dict[str, Any]:
         """Create data for the output results of walls."""
         walls_output: Dict[str, Any] = {}
         wall_index = 0
@@ -99,7 +95,7 @@ class ScoreOutputBuilder:
         for wall_label in range(TOTAL_WALLS - 1, -1, -1):
             wall_name = f"wall_{wall_label}_temperature"
             wall = {}
-            wall["MD"] = measured_depths.tolist()
+            wall["MD"] = measured_depths
             wall_temperatures = results.get_profile_curve(
                 wall_name, self.element_name, -1
             ).image.GetValues(TEMPERATURE_UNIT)
@@ -114,14 +110,15 @@ class ScoreOutputBuilder:
         """Create data for the output results."""
         results = Results(alfasim_results_filepath)
         well_start_position = self.score_data.get_well_start_position().GetValue(LENGTH_UNIT)
-        measured_depths = well_start_position + np.array(
-            results.get_profile_curve("pressure", self.element_name, -1).domain.GetValues(
+        measured_depths = list(
+            well_start_position
+            + results.get_profile_curve("pressure", self.element_name, -1).domain.GetValues(
                 LENGTH_UNIT
             )
         )
         return {
             "annuli": self._generate_annuli_output(results, measured_depths),
-            "MD": measured_depths.tolist(),
+            "MD": measured_depths,
             "production_tubing": self._generate_production_tubing_output(results),
             "layers": self._generate_walls_output(results, measured_depths),
         }


### PR DESCRIPTION
In this PR I update plugin generated alfacase with new entries and check if it can be opened in ALFAsim interface.
Here was also done a refactor to wrap the reader inside a class `ScoreInputData` that now provide all common functions to the builder classes that was previously spread across the classes duplicating a few code lines (e.g. `has_gas_lift` method). Some methods that are defining default values (as packer fluid properties, and the fluid default properties) they're now in this class.

![image](https://github.com/user-attachments/assets/0a57c446-45b5-42aa-95cb-f3feb137436d)


PWPA-2500