### PR TITLE
[PWPA-2551] Correct pvt model on well and change simulation regime to transient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ __pycache__/
 *.so
 
 # Distribution / packaging
+.vscode/settings.json
 .Python
 env/
 build/

--- a/src/alfasim_score/converter/alfacase/_tests/test_build_injection_alfacase/test_create_alfacase_injection.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_build_injection_alfacase/test_create_alfacase_injection.alfacase
@@ -1,7 +1,7 @@
 name: P27 - 3.0.0 - Teste (1)
 physics:
   hydrodynamic_model: hydrodynamic_model_3_layers_gas_oil_water
-  simulation_regime: simulation_regime_steady_state
+  simulation_regime: simulation_regime_transient
   energy_model: global_model
   solids_model: no_model
   solids_model_plugin_id:
@@ -786,6 +786,7 @@ nodes:
       max_rate_of_change: 1e+50
 wells:
 - name: WELLBORE
+  pvt_model: Water
   stagnant_fluid: fluid_default
   profile:
     x_and_y:

--- a/src/alfasim_score/converter/alfacase/_tests/test_build_production_alfacase/test_create_alfacase_gas_lift_production.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_build_production_alfacase/test_create_alfacase_gas_lift_production.alfacase
@@ -723,6 +723,7 @@ nodes:
       max_rate_of_change: 1e+50
 wells:
 - name: WELLBORE
+  pvt_model: DFLT_BLACK_OIL_27.40_230.00_1.17
   stagnant_fluid: fluid_default
   profile:
     x_and_y:

--- a/src/alfasim_score/converter/alfacase/_tests/test_build_production_alfacase/test_create_alfacase_natural_flow_production.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_build_production_alfacase/test_create_alfacase_natural_flow_production.alfacase
@@ -1,7 +1,7 @@
 name: Teste Térmico
 physics:
   hydrodynamic_model: hydrodynamic_model_4_fields
-  simulation_regime: simulation_regime_steady_state
+  simulation_regime: simulation_regime_transient
   energy_model: global_model
   solids_model: no_model
   solids_model_plugin_id:
@@ -723,6 +723,7 @@ nodes:
       max_rate_of_change: 1e+50
 wells:
 - name: WELLBORE
+  pvt_model: DFLT_BLACK_OIL_27.40_230.00_1.17
   stagnant_fluid: fluid_default
   profile:
     x_and_y:

--- a/src/alfasim_score/converter/alfacase/_tests/test_convert_alfacase/test_create_alfacase_file_score_input_annulus_temp_table_.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_convert_alfacase/test_create_alfacase_file_score_input_annulus_temp_table_.alfacase
@@ -1,7 +1,7 @@
 name: Térmico - Produtor
 physics:
   hydrodynamic_model: hydrodynamic_model_4_fields
-  simulation_regime: simulation_regime_steady_state
+  simulation_regime: simulation_regime_transient
   energy_model: global_model
   solids_model: no_model
   solids_model_plugin_id:
@@ -818,6 +818,7 @@ nodes:
       max_rate_of_change: 1e+50
 wells:
 - name: WELLBORE
+  pvt_model: DFLT_BLACK_OIL_29.00_0_225.00_0.92
   stagnant_fluid: fluid_default
   profile:
     x_and_y:

--- a/src/alfasim_score/converter/alfacase/_tests/test_convert_alfacase/test_create_alfacase_file_score_input_injection_operation_.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_convert_alfacase/test_create_alfacase_file_score_input_injection_operation_.alfacase
@@ -1,7 +1,7 @@
 name: P27 - 3.0.0 - Teste (1)
 physics:
   hydrodynamic_model: hydrodynamic_model_3_layers_gas_oil_water
-  simulation_regime: simulation_regime_steady_state
+  simulation_regime: simulation_regime_transient
   energy_model: global_model
   solids_model: no_model
   solids_model_plugin_id:
@@ -786,6 +786,7 @@ nodes:
       max_rate_of_change: 1e+50
 wells:
 - name: WELLBORE
+  pvt_model: Water
   stagnant_fluid: fluid_default
   profile:
     x_and_y:

--- a/src/alfasim_score/converter/alfacase/_tests/test_convert_alfacase/test_create_alfacase_file_score_input_natural_flow_.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_convert_alfacase/test_create_alfacase_file_score_input_natural_flow_.alfacase
@@ -1,7 +1,7 @@
 name: Teste Térmico
 physics:
   hydrodynamic_model: hydrodynamic_model_4_fields
-  simulation_regime: simulation_regime_steady_state
+  simulation_regime: simulation_regime_transient
   energy_model: global_model
   solids_model: no_model
   solids_model_plugin_id:
@@ -723,6 +723,7 @@ nodes:
       max_rate_of_change: 1e+50
 wells:
 - name: WELLBORE
+  pvt_model: DFLT_BLACK_OIL_27.40_230.00_1.17
   stagnant_fluid: fluid_default
   profile:
     x_and_y:

--- a/src/alfasim_score/converter/alfacase/_tests/test_convert_base_alfacase/test_create_alfacase_base.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_convert_base_alfacase/test_create_alfacase_base.alfacase
@@ -345,6 +345,7 @@ nodes:
       max_rate_of_change: 1e+50
 wells:
 - name: WELLBORE
+  pvt_model: DFLT_BLACK_OIL_27.40_230.00_1.17
   stagnant_fluid: fluid_default
   profile:
     x_and_y:

--- a/src/alfasim_score/converter/alfacase/_tests/test_convert_base_alfacase/test_create_alfacase_base_operation_configuration.alfacase
+++ b/src/alfasim_score/converter/alfacase/_tests/test_convert_base_alfacase/test_create_alfacase_base_operation_configuration.alfacase
@@ -1,7 +1,7 @@
 name: Teste Térmico
 physics:
   hydrodynamic_model: hydrodynamic_model_3_layers_gas_oil_water
-  simulation_regime: simulation_regime_steady_state
+  simulation_regime: simulation_regime_transient
   energy_model: global_model
   solids_model: no_model
   solids_model_plugin_id:
@@ -702,6 +702,7 @@ nodes:
       max_rate_of_change: 1e+50
 wells:
 - name: WELLBORE
+  pvt_model: DFLT_BLACK_OIL_27.40_230.00_1.17
   stagnant_fluid: fluid_default
   profile:
     x_and_y:

--- a/src/alfasim_score/converter/alfacase/base_operation.py
+++ b/src/alfasim_score/converter/alfacase/base_operation.py
@@ -201,7 +201,7 @@ class BaseOperationBuilder:
         alfacase.physics = PhysicsDescription(
             hydrodynamic_model=HydrodynamicModelType.ThreeLayersGasOilWater,
             energy_model=EnergyModel.GlobalModel,
-            simulation_regime=SimulationRegimeType.SteadyState,
+            simulation_regime=SimulationRegimeType.Transient,
             initial_condition_strategy=InitialConditionStrategyType.Constant,
         )
 

--- a/src/alfasim_score/converter/alfacase/base_operation.py
+++ b/src/alfasim_score/converter/alfacase/base_operation.py
@@ -201,7 +201,7 @@ class BaseOperationBuilder:
         alfacase.physics = PhysicsDescription(
             hydrodynamic_model=HydrodynamicModelType.ThreeLayersGasOilWater,
             energy_model=EnergyModel.GlobalModel,
-            # TODO: Switch to transient because the steady-state simulation is not converging.
+            # TODO PWPA-2556: Switch to transient because the steady-state simulation is not converging.
             # Need to check how this setting comes from SCORE,
             # since it's unclear why we always assume steady-state for the production.
             simulation_regime=SimulationRegimeType.Transient,

--- a/src/alfasim_score/converter/alfacase/base_operation.py
+++ b/src/alfasim_score/converter/alfacase/base_operation.py
@@ -201,6 +201,9 @@ class BaseOperationBuilder:
         alfacase.physics = PhysicsDescription(
             hydrodynamic_model=HydrodynamicModelType.ThreeLayersGasOilWater,
             energy_model=EnergyModel.GlobalModel,
+            # TODO: Switch to transient because the steady-state simulation is not converging.
+            # Need to check how this setting comes from SCORE,
+            # since it's unclear why we always assume steady-state for the production.
             simulation_regime=SimulationRegimeType.Transient,
             initial_condition_strategy=InitialConditionStrategyType.Constant,
         )

--- a/src/alfasim_score/converter/alfacase/convert_alfacase.py
+++ b/src/alfasim_score/converter/alfacase/convert_alfacase.py
@@ -257,6 +257,7 @@ class ScoreAlfacaseConverter:
         """Create the description for the well."""
         return WellDescription(
             name=WELLBORE_NAME,
+            pvt_model=self.score_data.operation_data["fluid"],
             stagnant_fluid=FLUID_DEFAULT_NAME,
             profile=self._convert_well_trajectory(),
             casing=self._convert_casings(),

--- a/src/alfasim_score/converter/alfacase/convert_alfacase.py
+++ b/src/alfasim_score/converter/alfacase/convert_alfacase.py
@@ -257,6 +257,8 @@ class ScoreAlfacaseConverter:
         """Create the description for the well."""
         return WellDescription(
             name=WELLBORE_NAME,
+            # TODO: For now, we are using ALFAsim's correlation as the wellbore fluid,
+            # since the provided PVT table is breaking the simulation.
             pvt_model=self.score_data.operation_data["fluid"],
             stagnant_fluid=FLUID_DEFAULT_NAME,
             profile=self._convert_well_trajectory(),

--- a/src/alfasim_score/converter/alfacase/convert_alfacase.py
+++ b/src/alfasim_score/converter/alfacase/convert_alfacase.py
@@ -257,7 +257,7 @@ class ScoreAlfacaseConverter:
         """Create the description for the well."""
         return WellDescription(
             name=WELLBORE_NAME,
-            # TODO PWPA-2557: For now, we are using ALFAsim's correlation as the wellbore fluid,
+            # TODO PWPA-2545: For now, we are using ALFAsim's correlation as the wellbore fluid,
             # since the provided PVT table is breaking the simulation.
             pvt_model=self.score_data.operation_data["fluid"],
             stagnant_fluid=FLUID_DEFAULT_NAME,

--- a/src/alfasim_score/converter/alfacase/convert_alfacase.py
+++ b/src/alfasim_score/converter/alfacase/convert_alfacase.py
@@ -257,7 +257,7 @@ class ScoreAlfacaseConverter:
         """Create the description for the well."""
         return WellDescription(
             name=WELLBORE_NAME,
-            # TODO: For now, we are using ALFAsim's correlation as the wellbore fluid,
+            # TODO PWPA-2557: For now, we are using ALFAsim's correlation as the wellbore fluid,
             # since the provided PVT table is breaking the simulation.
             pvt_model=self.score_data.operation_data["fluid"],
             stagnant_fluid=FLUID_DEFAULT_NAME,

--- a/src/alfasim_score/converter/alfacase/production_operation.py
+++ b/src/alfasim_score/converter/alfacase/production_operation.py
@@ -136,6 +136,9 @@ class ProductionOperationBuilder(BaseOperationBuilder):
                 if self.has_water(alfacase)
                 else HydrodynamicModelType.FourFields
             ),
+            # TODO: Switch to transient because the steady-state simulation is not converging.
+            # Need to check how this setting comes from SCORE,
+            # since it's unclear why we always assume steady-state for the production.
             simulation_regime=SimulationRegimeType.Transient,
         )
 

--- a/src/alfasim_score/converter/alfacase/production_operation.py
+++ b/src/alfasim_score/converter/alfacase/production_operation.py
@@ -136,7 +136,7 @@ class ProductionOperationBuilder(BaseOperationBuilder):
                 if self.has_water(alfacase)
                 else HydrodynamicModelType.FourFields
             ),
-            # TODO: Switch to transient because the steady-state simulation is not converging.
+            # TODO PWPA-2556: Switch to transient because the steady-state simulation is not converging.
             # Need to check how this setting comes from SCORE,
             # since it's unclear why we always assume steady-state for the production.
             simulation_regime=SimulationRegimeType.Transient,

--- a/src/alfasim_score/converter/alfacase/production_operation.py
+++ b/src/alfasim_score/converter/alfacase/production_operation.py
@@ -136,11 +136,7 @@ class ProductionOperationBuilder(BaseOperationBuilder):
                 if self.has_water(alfacase)
                 else HydrodynamicModelType.FourFields
             ),
-            simulation_regime=(
-                SimulationRegimeType.Transient
-                if self.score_data.has_gas_lift()
-                else SimulationRegimeType.SteadyState
-            ),
+            simulation_regime=SimulationRegimeType.Transient,
         )
 
     def configure_nodes(self, alfacase: CaseDescription) -> None:


### PR DESCRIPTION
This PR changes the simulation regime to transient, since steady state was not working, and also adds the appropriate pvt_model to the alfacases.

The image below shows a case run through a converted alfacase with values successfully obtained:

![{82C8A893-FAD6-42CA-9EBE-999C03FF2C92}](https://github.com/user-attachments/assets/04bcbde7-3a45-46eb-a388-8f7fb6d371ac)


[PWPA-2551]

[PWPA-2551]: https://esss.atlassian.net/browse/PWPA-2551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ